### PR TITLE
Suggested change and commentary

### DIFF
--- a/comp.org
+++ b/comp.org
@@ -248,7 +248,7 @@ Typical use would be to populate an =-opts= element with something like this:
   fn empty { nop }
 #+end_src
 
-=comp:files= completes filenames, using any typed prefix as the stem. If the =&regex= option is specified, only files matching that pattern are completcomed. If =&only-dirs= is =$true=, only directories are returned.
+=comp:files= completes filenames, using any typed prefix as the stem. If the =&regex= option is specified, only files matching that pattern are completed. If =&only-dirs= is =$true=, only directories are returned.
 
 #+begin_src elvish
   fn files [arg &regex='' &dirs-only=$false]{

--- a/comp.org
+++ b/comp.org
@@ -69,10 +69,10 @@ The base building block is the "completion definition item", can be one of the f
 
 *Example #1:* a simple completer for =cd=
 
-In this case, we define a function which receives the current "stem" (the part of the filename the user has typed so far) and expands all the files that match that prefix, then filters those which are directories, and returns them as completion possibilities. We pass the function directly as a completion item to =comp:expand=.
+In this case, we define a function which receives the current "stem" (the part of the filename the user has typed so far) and offers all the relevant files, then filters those which are directories, and returns them as completion possibilities. We pass the function directly as a completion item to =comp:expand=.
 
 #+begin_src elvish
-  fn complete-dirs [arg]{ put $arg*[match-hidden] | each [x]{ if (-is-dir $x) { put $x } } }
+  fn complete-dirs [arg]{ edit:complete-filename $arg | each [x]{ if (-is-dir $x) { put $x } } }
   edit:completion:arg-completer[cd] = [@cmd]{ comp:expand $complete-dirs~ $@cmd }
 #+end_src
 
@@ -96,7 +96,7 @@ Completion items can be aggregated in a /sequence of items/ when you need to pro
 
 - =-seq= (mandatory) containing an array of base definition items, which will be applied depending on their position within the command parameter sequence. If the the last element of the list is the string =...= (three periods), then next-to-last element of the list is repeated for all later arguments. If no completions should be provided past the last argument, simply omit the periods. If a sequence should produce no completions at all, you can use an empty list =[]=. If any specific elements of the sequence should have no completions, you can specify ={ comp:empty }= as its value.
 - =-opts= (optional) may contain a single definition item which produces a list of command-line options that are allowed at the beginning of the command, when no other arguments have been provided. Options can be specified in either of the following formats:
-  - As a string which gets converted to a long-style option; e.g. ='all'= to specify the =--all= option. The string must not contain the dashes at the beginning.
+  - As a string which gets converted to a long-style option; e.g. =all= to specify the =--all= option. The string must not contain the dashes at the beginning.
   - As a map which may contain the following keys: =short= for the short one-letter option, =long= for the long-option string, and =desc= for a descriptive string which gets shown in the completion menu. For example:
     #+begin_example
       [ &short= a &long=all &desc="Show all items" ]
@@ -248,11 +248,11 @@ Typical use would be to populate an =-opts= element with something like this:
   fn empty { nop }
 #+end_src
 
-=comp:files= completes filenames, using any typed prefix as the stem. If the =&regex= option is specified, only files matching that pattern are completed. If =&only-dirs= is =$true=, only directories are returned.
+=comp:files= completes filenames, using any typed prefix as the stem. If the =&regex= option is specified, only files matching that pattern are completcomed. If =&only-dirs= is =$true=, only directories are returned.
 
 #+begin_src elvish
   fn files [arg &regex='' &dirs-only=$false]{
-    put {$arg}*[match-hidden][nomatch-ok] | each [x]{
+    edit:complete-filename $arg | each [x]{
       if (and (or (not $dirs-only) (-is-dir $x)) (or (eq $regex '') (re:match $regex $x))) {
         put $x
       }


### PR DESCRIPTION
One note on the API design: I think it will be much cleaner if you organize the API around completer, and offer the *-wrapper functions as a first-class interface. Right now you have the `expand` command peek into the shape of `$def` to determine what kind of completer to generate: using your example of `brew`:

```
brew-completions = [
  &-opts= [ version ]
  &install= [
    &-opts= [ (brew install -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()') ]
    &-seq= [ { brew search | comp:decorate &style=green } ... ]
  ]
  &uninstall= [
    &-opts= [ (brew uninstall -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()') ]
    &-seq= [ { brew list | comp:decorate &style=red } ... ]
  ]
  &cat= [ &-seq= [ { brew search } ] ]
]

edit:completion:arg-completer[brew] = (comp:expand-wrapper $brew-completions)
```

Basically you are building a DSL with Elvish lists and maps. This is fine for now, but functions can encode information more flexibly and don't require explicit parsing.

```
edit:completion:arg-completer[brew] = (comp:subcommands [
  &install=(comp:sequence { brew search | comp:decorate &style=green } ... \
            &opts=[(brew install -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()')])
  &uninstall=(comp:sequence { brew list | comp:decorate &style=red } ... \
              &opts=[(brew uninstall -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()')]
  &cat=(comp:sequence { brew search })
] &opts=[version])
```

This incorporates several ideas:

* The commands `comp:subcommands` and `comp:sequence` now both output a completer (like their `-wrapper` counterparts in your version)

* `comp:subcommands` accepts the subcommand completer map as the argument, and the option map as an option.

* `comp:sequence` accepts the argument completers as arguments, and the option map as an option.