### PR TITLE
Completion framework API redesign

### DIFF
--- a/builtins.elv
+++ b/builtins.elv
@@ -1,15 +1,11 @@
 use ./comp
 use re
 
-use-completer = [
-  &-seq= [
-    { put ~/.elvish/lib/**[nomatch-ok].elv | each [m]{
-        if (not (-is-dir $m)) {
-          re:replace ~/.elvish/lib/'(.*).elv' '$1' $m
-        }
+edit:completion:arg-completer[use] = (comp:sequence {
+    put ~/.elvish/lib/**[nomatch-ok].elv | each [m]{
+      if (not (-is-dir $m)) {
+        re:replace ~/.elvish/lib/'(.*).elv' '$1' $m
       }
     }
-  ]
-]
-
-edit:completion:arg-completer[use] = (comp:expand-wrapper $use-completer)
+  }
+)

--- a/builtins.org
+++ b/builtins.org
@@ -41,16 +41,12 @@ Load the completion framework and other libraries.
 Completer for the =use= command, which includes all modules in =~/.elvish/lib/=.
 
 #+begin_src elvish
-  use-completer = [
-    &-seq= [
-      { put ~/.elvish/lib/**[nomatch-ok].elv | each [m]{
-          if (not (-is-dir $m)) {
-            re:replace ~/.elvish/lib/'(.*).elv' '$1' $m
-          }
+  edit:completion:arg-completer[use] = (comp:sequence {
+      put ~/.elvish/lib/**[nomatch-ok].elv | each [m]{
+        if (not (-is-dir $m)) {
+          re:replace ~/.elvish/lib/'(.*).elv' '$1' $m
         }
       }
-    ]
-  ]
-
-  edit:completion:arg-completer[use] = (comp:expand-wrapper $use-completer)
+    }
+  )
 #+end_src

--- a/cd.elv
+++ b/cd.elv
@@ -2,10 +2,6 @@ use ./comp
 
 dir-style = 'blue;bold'
 
-completions = [
-  &-seq= [
-    [stem]{ comp:files $stem &dirs-only | comp:decorate &style=$dir-style &code-suffix=/ }
-  ]
-]
-
-edit:completion:arg-completer[cd] = (comp:expand-wrapper $completions)
+edit:completion:arg-completer[cd] = (comp:sequence [stem]{
+    comp:files $stem &dirs-only | comp:decorate &style=$dir-style &code-suffix=/
+  })

--- a/cd.elv
+++ b/cd.elv
@@ -2,6 +2,6 @@ use ./comp
 
 dir-style = 'blue;bold'
 
-edit:completion:arg-completer[cd] = (comp:sequence [stem]{
+edit:completion:arg-completer[cd] = (comp:sequence [[stem]{
     comp:files $stem &dirs-only | comp:decorate &style=$dir-style &code-suffix=/
-  })
+  }])

--- a/cd.org
+++ b/cd.org
@@ -9,7 +9,7 @@
 
   dir-style = 'blue;bold'
 
-  edit:completion:arg-completer[cd] = (comp:sequence [stem]{
+  edit:completion:arg-completer[cd] = (comp:sequence [[stem]{
       comp:files $stem &dirs-only | comp:decorate &style=$dir-style &code-suffix=/
-    })
+    }])
 #+end_src

--- a/cd.org
+++ b/cd.org
@@ -9,11 +9,7 @@
 
   dir-style = 'blue;bold'
 
-  completions = [
-    &-seq= [
-      [stem]{ comp:files $stem &dirs-only | comp:decorate &style=$dir-style &code-suffix=/ }
-    ]
-  ]
-
-  edit:completion:arg-completer[cd] = (comp:expand-wrapper $completions)
+  edit:completion:arg-completer[cd] = (comp:sequence [stem]{
+      comp:files $stem &dirs-only | comp:decorate &style=$dir-style &code-suffix=/
+    })
 #+end_src

--- a/comp.elv
+++ b/comp.elv
@@ -17,7 +17,7 @@ fn decorate [@input &code-suffix='' &display-suffix='' &suffix='' &style='']{
 fn empty { nop }
 
 fn files [arg &regex='' &dirs-only=$false]{
-  edit:complete-filename $arg | each [x]{
+  put {$arg}*[match-hidden][nomatch-ok] | each [x]{
     if (and (or (not $dirs-only) (-is-dir $x)) (or (eq $regex '') (re:match $regex $x))) {
       put $x
     }
@@ -39,10 +39,10 @@ fn extract-opts [@cmd &regex='(?:-(\w),\s*)?--([\w-]+).*?\s\s(\w.*)$']{
 }
 
 # Forward declarations to be overriden later
-fn sequence { }
-fn subcommands { }
+fn -sequence { }
+fn -subcommands { }
 
-fn expand [def @cmd]{
+fn -expand [def @cmd]{
   arg = $cmd[-1]
   what = (kind-of $def)
   if (eq $what 'fn') {
@@ -58,18 +58,18 @@ fn expand [def @cmd]{
     explode $def
   } elif (eq $what 'map') {
     if (has-key $def '-seq') {
-      sequence $def $@cmd
+      -sequence $def $@cmd
     } else {
-      subcommands $def $@cmd
+      -subcommands $def $@cmd
     }
   }
 }
 
-sequence~ = [def @cmd]{
+-sequence~ = [def @cmd]{
 
 opts = []
 if (has-key $def -opts) {
-  expand $def[-opts] $@cmd | each [opt]{
+  -expand $def[-opts] $@cmd | each [opt]{
     if (eq (kind-of $opt) map) {
       opts = [ $@opts $opt ]
     } else {
@@ -99,31 +99,53 @@ explode $def[-seq] | each [f]{
 edit:complete-getopt $cmd[1:] $opts $handlers
 }
 
-subcommands~ = [def @cmd]{
+-subcommands~ = [def @cmd]{
   subcommands = [(keys (dissoc $def -opts))]
-  first-subcommand = [(range 1 (count $cmd) | each [i]{
+  n = (count $cmd)
+  kw = [(range 1 $n | each [i]{
         if (has-value $subcommands $cmd[$i]) { put $cmd[$i] $i }
   })]
-  if (not-eq $first-subcommand []) {
-    subcommand subcommand-pos = $first-subcommand[0 1]
-    if (eq (kind-of $def[$subcommand]) 'string') {
-      subcommands $def (explode $cmd[0:$subcommand-pos]) $def[$subcommand] (explode $cmd[(+ $subcommand-pos 1):])
+  if (and (not-eq $kw []) (not-eq $kw[1] (- $n 1))) {
+    sc sc-pos = $kw[0 1]
+    if (eq (kind-of $def[$sc]) 'string') {
+      cmd[$sc-pos] = $def[$sc]
+      -subcommands $def $@cmd
     } else {
-      expand $def[$subcommand] (explode $cmd[{$subcommand-pos}:])
+      $def[$sc] (explode $cmd[{$sc-pos}:])
     }
   } else {
     top-def = [ &-seq= [ { put $@subcommands }] ]
     if (has-key $def -opts) {
       top-def[-opts] = $def[-opts]
     }
-    sequence $top-def $@cmd
+    -sequence $top-def $@cmd
   }
 }
 
 fn -wrapper-gen [func]{
-  put [def]{ put [@cmd]{ $func $def $@cmd } }
+  put [def &pre-hook=$nop~ &post-hook=$nop~ &post-filter=$all~]{
+    put [@cmd]{
+      $pre-hook $@cmd
+      result = [($func $def $@cmd)]
+      $post-hook $result $@cmd
+      put $@result
+    }
+  }
 }
 
-expand-wrapper~ = (-wrapper-gen $expand~)
-sequence-wrapper~ = (-wrapper-gen $sequence~)
-subcommands-wrapper~ = (-wrapper-gen $subcommands~)
+-expand-wrapper~      = (-wrapper-gen $-expand~)
+-sequence-wrapper~    = (-wrapper-gen $-sequence~)
+-subcommands-wrapper~ = (-wrapper-gen $-subcommands~)
+
+fn item [item &pre-hook=$nop~ &post-hook=$nop~]{
+  -expand-wrapper $item &pre-hook=$pre-hook &post-hook=$post-hook
+}
+
+fn sequence [@sequence &opts=[] &pre-hook=$nop~ &post-hook=$nop~]{
+  -sequence-wrapper [&-seq=$sequence &-opts=$opts] &pre-hook=$pre-hook &post-hook=$post-hook
+}
+
+fn subcommands [def &opts=[] &pre-hook=$nop~ &post-hook=$nop~]{
+  subcmd-map = (assoc $def -opts $opts)
+  -subcommands-wrapper $subcmd-map &pre-hook=$pre-hook &post-hook=$post-hook
+}

--- a/comp.elv
+++ b/comp.elv
@@ -24,10 +24,13 @@ fn files [arg &regex='' &dirs-only=$false]{
   }
 }
 
-fn extract-opts [@cmd &regex='(?:-(\w),\s*)?--([\w-]+).*?\s\s(\w.*)$']{
+fn extract-opts [@cmd
+  &regex='(?:-(\w),\s*)?--([\w-]+).*?\s\s(\w.*)$'
+  &regex-map=[&short=1 &long=2 &desc=3]
+]{
   all | each [l]{
   re:find $regex $l } | each [m]{
-    short long desc = $m[groups][1 2 3][text]
+    short long desc = $m[groups][$regex-map[short long desc]][text]
     opt = [&]
     if (not-eq $short '') { opt[short] = $short }
     if (not-eq $long  '') { opt[long]  = $long  }

--- a/comp.elv
+++ b/comp.elv
@@ -43,14 +43,10 @@ fn extract-opts [@cmd
 
 fn -handler-arity [func]{
   fnargs = [ (count $func[arg-names]) (not-eq $func[rest-arg] '') ]
-  if (eq $fnargs [ 0 $false ]) {
-    put no-args
-  } elif (eq $fnargs [ 1 $false ]) {
-    put one-arg
-  } elif (eq $fnargs [ 0 $true ]) {
-    put rest-arg
-  } else {
-    put other-args
+  if     (eq $fnargs [ 0 $false ]) { put no-args
+  } elif (eq $fnargs [ 1 $false ]) { put one-arg
+  } elif (eq $fnargs [ 0 $true  ]) { put rest-arg
+  } else {                           put other-args
   }
 }
 
@@ -103,20 +99,23 @@ edit:complete-getopt $cmd[1:] $final-opts $final-handlers
 }
 
 fn -expand-subcommands [def @cmd &opts=[]]{
-  subcommands = [(keys $def)]
-  n = (count $cmd)
-  kw = [(range 1 $n | each [i]{
-        if (has-value $subcommands $cmd[$i]) { put $cmd[$i] $i }
-  })]
-  if (and (not-eq $kw []) (not-eq $kw[1] (- $n 1))) {
-    sc sc-pos = $kw[0 1]
-    if (eq (kind-of $def[$sc]) 'string') {
-      cmd[$sc-pos] = $def[$sc]
-      -expand-subcommands &opts=$opts $def $@cmd
-    } else {
-      $def[$sc] (explode $cmd[{$sc-pos}:])
-    }
+
+subcommands = [(keys $def)]
+n = (count $cmd)
+kw = [(range 1 $n | each [i]{
+      if (has-value $subcommands $cmd[$i]) { put $cmd[$i] $i }
+})]
+
+if (and (not-eq $kw []) (not-eq $kw[1] (- $n 1))) {
+  sc sc-pos = $kw[0 1]
+  if (eq (kind-of $def[$sc]) 'string') {
+    cmd[$sc-pos] = $def[$sc]
+    -expand-subcommands &opts=$opts $def $@cmd
   } else {
+    $def[$sc] (explode $cmd[{$sc-pos}:])
+  }
+
+} else {
     top-def = [ { put $@subcommands } ]
     -expand-sequence &opts=$opts $top-def $@cmd
   }

--- a/comp.elv
+++ b/comp.elv
@@ -46,6 +46,8 @@ fn -handler-arity [func]{
     put one-arg
   } elif (eq $fnargs [ 0 $true ]) {
     put rest-arg
+  } else {
+    put other-args
   }
 }
 
@@ -56,6 +58,7 @@ fn -expand-item [def @cmd]{
     [ &no-args=  { $def }
       &one-arg=  { $def $arg }
       &rest-arg= { $def $@cmd }
+      &other-args= { put '<completion-fn-arity-error>' }
     ][(-handler-arity $def)]
   } elif (eq $what 'list') {
     explode $def
@@ -83,6 +86,7 @@ final-handlers = [(
           &no-args=  [_]{ $f }
           &one-arg=  $f
           &rest-arg= [_]{ $f $@cmd }
+          &other-args= [_]{ put '<completion-fn-arity-error>' }
         ][(-handler-arity $f)]
       } elif (eq (kind-of $f) 'list') {
         put [_]{ explode $f }
@@ -124,7 +128,7 @@ fn item [item &pre-hook=$nop~ &post-hook=$nop~]{
   }
 }
 
-fn sequence [@sequence &opts=[] &pre-hook=$nop~ &post-hook=$nop~]{
+fn sequence [sequence &opts=[] &pre-hook=$nop~ &post-hook=$nop~]{
   put [@cmd]{
     $pre-hook $@cmd
     result = [(-expand-sequence &opts=$opts $sequence $@cmd)]

--- a/comp.org
+++ b/comp.org
@@ -9,9 +9,9 @@ This file is written in [[http://www.howardism.org/Technical/Emacs/literate-prog
 * Table of Contents                                          :TOC_3:noexport:
 - [[#usage][Usage]]
   - [[#completion-definitions][Completion definitions]]
-    - [[#base-completion-items][Base completion items]]
-    - [[#completion-sequences][Completion sequences]]
-    - [[#subcommand-completion][Subcommand completion]]
+    - [[#items][Items]]
+    - [[#sequences][Sequences]]
+    - [[#subcommands][Subcommands]]
   - [[#utility-functions][Utility functions]]
 - [[#implementation][Implementation]]
   - [[#utility-functions-1][Utility functions]]
@@ -37,69 +37,59 @@ From the file where you will define your completions, load this module:
   use github.com/zzamboni/elvish-completions/comp
 #+end_src
 
-The main entry point for this module is =comp:-expand-item=. It receives two arguments:
-
-- A "completion definition", which in general, indicates how the completions will be produced. See below for details.
-- The contents of the command line so far, as passed to the [[https://elvish.io/ref/edit.html#argument-completer][argument completer functions]].
-
-This function returns any available completions according to its definition and the current command line. It needs to be called from within the argument completer for the corresponding command, so that its result are offered by Elvish to the user. A typical way of doing this would be like this (where =command= is the command for which you are defining the completions, and =$def= contains the completion definition data structure):
+The main entry points for this module are =comp:item=, =comp:sequence= and =comp:subcommands=. Each one receives a single argument containing a  "completion definition", which indicates how the completions will be produced. Each one receives a different kind of completion structure, and receives a corresponding completion function, which receives the current contents of the command line (as passed to the [[https://elvish.io/ref/edit.html#argument-completer][argument completer functions]]) and returns the appropriate completions. The function returned by the =comp:*= functions can be assigned directly to an element of =$edit:completion:arg-completer=. A simple example:
 
 #+begin_src elvish
-  edit:completion:arg-completer[command] = [@cmd]{ comp:expand $def $@cmd }
+  edit:completion:arg-completer[foo] = (comp:item [ bar baz ])
 #+end_src
 
-For this common case, =comp= provides a helper function called =comp:-expand-wrapper=, which receives only the definition argument and returns a /function/ which can be assigned directly to the corresponding elements of =$edit:completion:arg-completer=, so that the code above can be written like this:
+If you type this in your terminal, and then type =foo<space>= and press ~Tab~, you will see the appropriate completions:
 
-#+begin_src elvish
-  edit:completion:arg-completer[command] = (comp:expand-wrapper $def)
-#+end_src
+#+begin_example
+> foo <Tab>
+ COMPLETING argument _
+ bar  baz
+#+end_example
 
-To create completions for new commands, your main task is to define a new completion definition. This is explained below, with examples of the different available structures and features.
+To create completions for new commands, your main task is to define the corresponding completion definition. The different types of definitions and functions are explained below, with examples of the different available structures and features.
 
 ** Completion definitions
-*** Base completion items
+*** Items
 
-The base building block is the "completion definition item", can be one of the following:
+The base building block is the "item", can be one of the following:
 
-- An array containing all the potential completions (the array can be empty, in which case no completions are provided).
-- A function which returns the potential completions (it can return nothing, in which case no completions are provided). The function should have one of the following arities, which affect which arguments will be passed to it:
-  - If it takes no arguments, no arguments are passed to it
-  - If it takes only a single argument, it gets the current (last) component of the command line =@cmd=
-  - If it takes only a rest argument, it gets the full current command line (the contents of =@cmd=)
+- An array containing all the potential completions (it can be empty, in which case no completions are provided). This is useful for providing a static list of completions.
+- A function which returns the potential completions (it can return nothing, in which case no completions are provided). The function should have one of the following arities, which affect which arguments will be passed to it (other arities are not valid, and in that case the item will not be executed):
+  - If it takes no arguments, no arguments are passed to it.
+  - If it takes a single argument, it gets the current (last) component of the command line =@cmd=
+  - If it takes a rest argument, it gets the full current command line (the contents of =@cmd=)
 
 *Example #1:* a simple completer for =cd=
 
 In this case, we define a function which receives the current "stem" (the part of the filename the user has typed so far) and offers all the relevant files, then filters those which are directories, and returns them as completion possibilities. We pass the function directly as a completion item to =comp:-expand=.
 
 #+begin_src elvish
-  fn complete-dirs [arg]{ edit:complete-filename $arg | each [x]{ if (-is-dir $x) { put $x } } }
-  edit:completion:arg-completer[cd] = [@cmd]{ comp:expand $complete-dirs~ $@cmd }
+  fn complete-dirs [arg]{ put {$arg}* | each [x]{ if (-is-dir $x) { put $x } } }
+  edit:completion:arg-completer[cd] = (comp:item $complete-dirs~)
 #+end_src
 
-I defined the =complete-dirs= function separately only for clarity - you can also embed the lambda directly as an argument to =comp:-expand.=
-
-In simple cases like the above, you can use the =comp:expand-wrapper= function to avoid defining the wrapper function by hand:
-
-#+begin_src elvish
-  edit:completion:arg-completer[cd] = (comp:expand-wrapper $complete-dirs~)
-#+end_src
+I defined the =complete-dirs= function separately only for clarity - you can also embed the lambda directly as an argument to =comp:item=.
 
 For file and directory completion, you can use the utility function =comp:files= instead of defining your own function (see [[*Utility functions][Utility functions]]):
 
 #+begin_src elvish
-  edit:completion:arg-completer[cd] = (comp:expand-wrapper [arg]{ comp:files $arg &dirs-only })
+  edit:completion:arg-completer[cd] = (comp:item [arg]{ comp:files $arg &dirs-only })
 #+end_src
 
-*** Completion sequences
+*** Sequences
 
-Completion items can be aggregated in a /sequence of items/ when you need to provide different completions for different positional arguments of a command. Sequences include support for command-line options at the beginning of the command. The definition structure in this case has to be a map with two indices:
+Completion items can be aggregated in a /sequence of items/ and used with the =comp:sequence= function when you need to provide different completions for different positional arguments of a command. Sequences include support for command-line options at the beginning of the command. The definition structure in this case has to be an array of items, which will be applied depending on their position within the command parameter sequence. If the the last element of the list is the string =...= (three periods), the next-to-last element of the list is repeated for all later arguments. If no completions should be provided past the last argument, simply omit the periods. If a sequence should produce no completions at all, you can use an empty list =[]=. If any specific elements of the sequence should have no completions, you can specify ={ comp:empty }= or =[]= as its value.
 
-- =-seq= (mandatory) containing an array of base definition items, which will be applied depending on their position within the command parameter sequence. If the the last element of the list is the string =...= (three periods), then next-to-last element of the list is repeated for all later arguments. If no completions should be provided past the last argument, simply omit the periods. If a sequence should produce no completions at all, you can use an empty list =[]=. If any specific elements of the sequence should have no completions, you can specify ={ comp:empty }= as its value.
-- =-opts= (optional) may contain a single definition item which produces a list of command-line options that are allowed at the beginning of the command, when no other arguments have been provided. Options can be specified in either of the following formats:
+If the =&opts= option is passed to the =comp:sequence= function, it must contain a single definition item which produces a list of command-line options that are allowed at the beginning of the command, when no other arguments have been provided. Options can be specified in either of the following formats:
   - As a string which gets converted to a long-style option; e.g. =all= to specify the =--all= option. The string must not contain the dashes at the beginning.
   - As a map which may contain the following keys: =short= for the short one-letter option, =long= for the long-option string, and =desc= for a descriptive string which gets shown in the completion menu. For example:
     #+begin_example
-      [ &short= a &long=all &desc="Show all items" ]
+      [ &short=a &long=all &desc="Show all items" ]
     #+end_example
 
 *Note:* options are only offered as completions when the use has typed a dash as the first character. Otherwise the argument completers are used.
@@ -107,80 +97,64 @@ Completion items can be aggregated in a /sequence of items/ when you need to pro
 *Example #2:* we can improve on the previous completer for =cd= by preventing more than one argument from being completed (only the first argument will be completed using =complete-dirs=, since the list does not end with =...=):
 
 #+begin_src elvish
-  edit:completion:arg-completer[cd] = (comp:expand-wrapper [ &-seq= [ [arg]{ comp:files $arg &dirs-only } ] ])
+  edit:completion:arg-completer[cd] = (comp:sequence [ [arg]{ comp:files $arg &dirs-only }])
 #+end_src
 
 *Example #3:* a simple completer for =ls= with a subset of its options. Note that =-l= and =-R= are only provided as completions when you have not typed any filenames yet. Also note that we are using [[*Utility functions][comp:decorate]] to display the files in a different color, and the =...= at the end of the sequence to use the same completer for all further elements.
 
 #+begin_src elvish
-  edit:completion:arg-completer[ls] = (comp:expand-wrapper [
-      &-opts= [
-        [ &short=l                 &desc='use a long listing format' ]
-        [ &short=R &long=recursive &desc='list subdirectories recursively' ]
-      ]
-      &-seq= [ [arg]{ put $arg* | comp:decorate &style=blue } ... ]
-  ])
+  ls-opts = [
+    [ &short=l                 &desc='use a long listing format' ]
+    [ &short=R &long=recursive &desc='list subdirectories recursively' ]
+  ]
+  edit:completion:arg-completer[ls] = (comp:sequence &opts=$ls-opts \
+    [ [arg]{ put $arg* | comp:decorate &style=blue } ... ]
+  )
 #+end_src
 
 *Example #4:* See the [[https://github.com/zzamboni/elvish-completions/blob/master/ssh.org][ssh completer]] for a real-world example of using sequences.
 
-*** Subcommand completion
+*** Subcommands
 
-Completion sequences can be further aggregated into /subcommand structures/ to provide completion for commands such as =git=.  In this case, the definition is a map indexed by subcommand names. The value of each element is a completion item (it can be a single item, a sequence, or another subcommand map). Each item must only correspond to the arguments of its corresponding subcommand. The subcommand map may also contain an entry with the index =-opts= containing a single item definition to generate any available top-level options (to appear before a subcommand). The subcommand definition can be another subcommand structure to provide completion for sub-sub-commands (see the example below for =vagrant=).
+Finally, completion sequences can be aggregated into /subcommand structures/ together with the =comp:subcommands= function, to provide completion for commands such as =git=, which accept multiple subcommands, each with their own options and completions. In this case, the definition is a map indexed by subcommand names. The value of each element can be a =comp:item=,  a =comp:sequence= or another =comp:subcommands= (to provide completion for sub-sub-commands, see the example below for =vagrant=). The =comp:subcommands= function can also receive option  =&opts= containing a single item definition to generate any available top-level options (to appear before the subcommand).
 
-*Example #5:* a simple completer for the =brew= package manager, with support for the =install=, =uninstall= and =cat= commands. =install= and =cat= gets as completions all available packages (the output of the =brew search= command), while =uninstall= only completes installed packages (the output of =brew list=). Note that for =install= and =uninstall= we automatically extract command-line options from their help messages, and pass them as the =-opts= element in the corresponding sequence definitions. Also note that all =-opts= elements get initialized at definition time (they are arrays), whereas the =-seq= completions get evaluated at runtime (they are lambdas), to automatically update according to the current packages. The =cat= command sequence allows only one option.
+*Example #5:* a simple completer for the =brew= package manager, with support for the =install=, =uninstall= and =cat= commands. =install= and =cat= gets as completions all available packages (the output of the =brew search= command), while =uninstall= only completes installed packages (the output of =brew list=). Note that for =install= and =uninstall= we automatically extract command-line options from their help messages using the =comp:extract-opts= function, and pass them as the =&opts= option in the corresponding sequence functions. Also note that all =&opts= elements get initialized at definition time (they are arrays), whereas the sequence completions get evaluated at runtime (they are lambdas), to automatically update according to the current packages. The =cat= command sequence allows only one option. The load-time initialization of the options incurs a small delay, and you could replace these with lambdas as well so that the options are computed at runtime.
 
 #+begin_src elvish
   brew-completions = [
-    &-opts= [ version ]
-    &install= [
-      &-opts= [ (brew install -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()') ]
-      &-seq= [ { brew search } ... ]
-    ]
-    &uninstall= [
-      &-opts= [ (brew uninstall -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()') ]
-      &-seq= [ { brew list } ... ]
-    ]
-    &cat= [ &-seq= [ { brew search } ] ]
+    &install= (comp:sequence \
+      &opts= [ (brew install -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()') ] \
+      [ { brew search } ... ]
+    )
+    &uninstall= (comp:sequence \
+      &opts= [ (brew uninstall -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()') ] \
+      [ { brew list } ... ]
+    )
+    &cat= (comp:sequence [{ brew search }])
   ]
 
-  edit:completion:arg-completer[brew] = (comp:expand-wrapper $brew-completions)
+  edit:completion:arg-completer[brew] = (comp:subcommands &opts= [ version ] $brew-completions)
 #+end_src
 
-#+begin_src elvish
-edit:completion:arg-completer[brew] = (comp:subcommands [
-  &install=(comp:sequence { brew search | comp:decorate &style=green } ... \
-            &opts=[(brew install -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()')])
-  &uninstall=(comp:sequence { brew list | comp:decorate &style=red } ... \
-              &opts=[(brew uninstall -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()')])
-  &cat=(comp:sequence { brew search })
-] &opts=[version])
-#+end_src
+*Example #6:* a simple completer for a subset of =vagrant=, which receives commands which may have subcommands and options of their own. Note that the value of =&up= is a =comp:sequence=, but the value of =&box= is another =comp:subcommands= which includes the completions for =box add= and =box remove=. Also note the use of the =comp:extract-opts= function to extract the command-line arguments automatically from the help messages.
 
-*Example #6:* a simple completer for a subset of =vagrant=, which receives commands which may have subcommands and options of their own. Note that the value of =&up= is a sequence, but the value of =&box= is a subcommand map which includes the completions for =box add= and =box remove=. Also note the use of the =comp:extract-opts= function to extract the command-line arguments automatically from the help messages.
-
-*Tip:* note that the values of =&-opts= are functions (e.g. ={ vagrant-opts up }=) instead of arrays (e.g. =( vagrant-opts up)=). Both would be valid, but in the latter case they would all be initialized at load time (when the data structure is defined), which might introduce a delay (particularly with more command definitions). By using functions the options are only extracted at runtime when the completion is requested. For further optimization, =vagrant-opts= could be made to memoize the values so that the delay only occurs the first time.
+*Tip:* note that the values of =&opts= are functions (e.g. ={ vagrant-up -h | comp:extract-opts }=) instead of arrays (e.g. =( vagrant up -h | comp:extract-opts )=). As mentioned in Example #5, both would be valid, but in the latter case they are all initialized at load time (when the data structure is defined), which might introduce a delay (particularly with more command definitions). By using functions the options are only extracted at runtime when the completion is requested. For further optimization, =vagrant-opts= could be made to memoize the values so that the delay only occurs the first time.
 
 #+begin_src elvish
   vagrant-completions = [
-    &-opts= [ version help ]
-    &up= [
-      &-opts= { vagrant up -h | comp:extract-opts }
-      &-seq= [ ]
-    ]
-    &box= [
-      &add= [
-        &-opts= { vagrant box add -h | comp:extract-opts }
-        &-seq= [ ]
-      ]
-      &remove= [
-        &-opts= { vagrant box remove -h | comp:extract-opts }
-        &-seq= [ { vagrant box list | eawk [_ @f]{ put $f[0] } } ... ]
-      ]
-    ]
-  ]
+    &up= (comp:sequence [] \
+      &opts= { vagrant up -h | comp:extract-opts }
+    )
+    &box= (comp:subcommands [
+        &add= (comp:sequence [] \
+          &opts= { vagrant box add -h | comp:extract-opts }
+        )
+        &remove= (comp:sequence [ { vagrant box list | eawk [_ @f]{ put $f[0] } } ... ] \
+          &opts= { vagrant box remove -h | comp:extract-opts }
+        )
+  ])]
 
-  edit:completion:arg-completer[vagrant] = (comp:expand-wrapper $vagrant-completions)
+  edit:completion:arg-completer[vagrant] = (comp:subcommands &opts= [ version help ] $vagrant-completions)
 #+end_src
 
 *Example #7:* See the [[https://github.com/zzamboni/elvish-completions/blob/master/git.org][git completer]] for a real-world subcommand completion example, which also shows how extensively auto-population of subcommands and options can be done by extracting information from help messages.
@@ -197,29 +171,28 @@ edit:completion:arg-completer[brew] = (comp:subcommands [
 
 The regular expression used to extract the options can be specified with the =&regex= option, which should have three groups, which get mapped to short, long and description, respectively.
 
-Typical use would be to populate an =-opts= element with something like this:
+Typical use would be to populate an =&opts= element with something like this:
 
 #+begin_src elvish
-  &-opts= { vagrant -h | comp:extract-opts }
+  comp:sequence &opts= { vagrant -h | comp:extract-opts } [ ... ]
 #+end_src
 
-*Example #8:* the =brew= completer shown before can be made to show package names and command-line options in different styles. Note how =comp:decorate= can get its arguments both as arguments (in the =-opts= assignments) and as pipeline input (in =-seq=). Also note the use of =comp:extract-opts= to generate the =-opts= elements from the output of the =brew= help commands.
+*Example #8:* the =brew= completer shown before can be made to show package names in different styles (green when installing, red when uninstalling).
 
 #+begin_src elvish
   brew-completions = [
-    &-opts= [ version ]
-    &install= [
-      &-opts= [ (brew install -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()') ]
-      &-seq= [ { brew search | comp:decorate &style=green } ... ]
-    ]
-  &uninstall= [
-      &-opts= [ (brew uninstall -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()') ]
-      &-seq= [ { brew list | comp:decorate &style=red } ... ]
-    ]
-    &cat= [ &-seq= [ { brew search } ] ]
+    &install= (comp:sequence \
+      &opts= [ (brew install -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()') ] \
+      [ { brew search | comp:decorate &style=green } ... ]
+    )
+    &uninstall= (comp:sequence \
+      &opts= [ (brew uninstall -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()') ] \
+      [ { brew list | comp:decorate &style=red } ... ]
+    )
+    &cat= (comp:sequence [{ brew search }])
   ]
 
-  edit:completion:arg-completer[brew] = (comp:expand-wrapper $brew-completions)
+  edit:completion:arg-completer[brew] = (comp:subcommands &opts= [ version ] $brew-completions)
 #+end_src
 
 * Implementation

--- a/comp.org
+++ b/comp.org
@@ -243,13 +243,18 @@ Typical use would be to populate an =&opts= element with something like this:
   }
 #+end_src
 
-=comp:extract-opts= takes input from the pipeline and parses it using a regular expression with three groups. Group #1 should be the short option letter, #2 is the long option name, and #3 is the description. At last one of short/long is mandatory, everything else is optional.
+*** comp:extract-opts
+
+=comp:extract-opts= takes input from the pipeline and parses it using a regular expression with three groups. By default, group #1 should be the short option letter, #2 is the long option name, and #3 is the description, but this is configurable with the =&regex-map= option. At last one of short/long is mandatory, everything else is optional. Returns an option map with keys =short=, =long= and =desc=, depending on the available groups. Only produces an output if at least =short= or =long= has a value.
 
 #+begin_src elvish
-  fn extract-opts [@cmd &regex='(?:-(\w),\s*)?--([\w-]+).*?\s\s(\w.*)$']{
+  fn extract-opts [@cmd
+    &regex='(?:-(\w),\s*)?--([\w-]+).*?\s\s(\w.*)$'
+    &regex-map=[&short=1 &long=2 &desc=3]
+  ]{
     all | each [l]{
     re:find $regex $l } | each [m]{
-      short long desc = $m[groups][1 2 3][text]
+      short long desc = $m[groups][$regex-map[short long desc]][text]
       opt = [&]
       if (not-eq $short '') { opt[short] = $short }
       if (not-eq $long  '') { opt[long]  = $long  }

--- a/comp.org
+++ b/comp.org
@@ -15,7 +15,15 @@ This file is written in [[http://www.howardism.org/Technical/Emacs/literate-prog
   - [[#utility-functions][Utility functions]]
 - [[#implementation][Implementation]]
   - [[#utility-functions-1][Utility functions]]
+    - [[#compdecorate][comp:decorate]]
+    - [[#compempty][comp:empty]]
+    - [[#compfiles][comp:files]]
+    - [[#compextract-opts][comp:extract-opts]]
+    - [[#comp-handler-arity][comp:-handler-arity]]
   - [[#completion-functions][Completion functions]]
+    - [[#comp-expand-item][comp:-expand-item]]
+    - [[#comp-expand-sequence][comp:-expand-sequence]]
+    - [[#comp-expand-subcommands][comp:-expand-subcommands]]
   - [[#completion-wrapper-functions][Completion wrapper functions]]
 
 * Usage
@@ -52,6 +60,12 @@ If you type this in your terminal, and then type =foo<space>= and press ~Tab~, y
 #+end_example
 
 To create completions for new commands, your main task is to define the corresponding completion definition. The different types of definitions and functions are explained below, with examples of the different available structures and features.
+
+All three functions can also receive options =&pre-hook= and =&post-hook=. If specified, they must be lambdas which get executed before and after the completion is processed, respectively. Hooks cannot modify the result, and they should usually not be necessary, but you can use them for any maintenance or update tasks.
+- =&pre-hook= must receive a single rest argument, and receives the current command line: =[@cmd]{ code }=
+- =&post-hook= must receive an array and a rest argument, and receives the generated completions and the current command line: =[result @cmd]{ code }=
+
+*Note:* the main entry points return a ready-to-use argument handler function. If you ever need to expand a completion definition directly (maybe for some advanced usage), you can call =comp:-expand-item=, =comp:-expand-sequence= and =comp:-expand-subcommands=, respectively. These functions all take the definition structure and the current command line, and return the appropriate completions at that point.
 
 ** Completion definitions
 *** Items
@@ -161,7 +175,16 @@ Finally, completion sequences can be aggregated into /subcommand structures/ tog
 
 ** Utility functions
 
-=comp:decorate= maps its input through =edit:complex-candidate= with the given options. Can be passed the same options as [[https://elvish.io/ref/edit.html#argument-completer][edit:complex-candidate]]. In addition, if =&suffix= is specified, it is used to set both =&display-suffix= and =&code-suffix=.
+=comp:decorate= maps its input through =edit:complex-candidate= with the given options. Can be passed the same options as [[https://elvish.io/ref/edit.html#argument-completer][edit:complex-candidate]]. In addition, if =&suffix= is specified, it is used to set both =&display-suffix= and =&code-suffix=. Input can be given either as arguments or through the pipeline:
+
+#+begin_src elvish
+> comp:decorate &suffix=":" foo bar
+▶ (edit:complex-candidate foo &code-suffix=: &display-suffix=: &style='')
+▶ (edit:complex-candidate bar &code-suffix=: &display-suffix=: &style='')
+> put foo bar | comp:decorate &style="red"
+▶ (edit:complex-candidate foo &code-suffix='' &display-suffix='' &style=31)
+▶ (edit:complex-candidate bar &code-suffix='' &display-suffix='' &style=31)
+#+end_src
 
 =comp:extract-opts= takes input from the pipeline and extracts command-line options from its output, assuming the following common format by default:
 
@@ -169,13 +192,13 @@ Finally, completion sequences can be aggregated into /subcommand structures/ tog
   -o, --option                Option description
 #+end_example
 
-The regular expression used to extract the options can be specified with the =&regex= option, which should have three groups, which get mapped to short, long and description, respectively.
-
 Typical use would be to populate an =&opts= element with something like this:
 
 #+begin_src elvish
   comp:sequence &opts= { vagrant -h | comp:extract-opts } [ ... ]
 #+end_src
+
+*Note:* The regular expression used to extract the options can be specified with the =&regex= option, which should have three groups, which get mapped to short, long and description, respectively. The mapping from the regex capture groups to the options can also be changed by passing the =&regex-map= option to =comp:extract-opts=. Its default value is =[&short=1 &long=2 &desc=3]=, which results in the default mapping, but if you need a different arrangement, you can reconfigure it.
 
 *Example #8:* the =brew= completer shown before can be made to show package names in different styles (green when installing, red when uninstalling).
 
@@ -201,12 +224,16 @@ Typical use would be to populate an =&opts= element with something like this:
 :header-args: :mkdirp yes :comments no
 :END:
 
+We start by loading some basic modules we need.
+
 #+begin_src elvish
   use re
   use github.com/zzamboni/elvish-modules/util
 #+end_src
 
 ** Utility functions
+
+*** comp:decorate
 
 =comp:decorate= maps its input through =edit:complex-candidate= with the given options. Can be passed the same options as [[https://elvish.io/ref/edit.html#argument-completer][edit:complex-candidate]]. In addition, if =&suffix= is specified, it is used to set both =&display-suffix= and =&code-suffix=.
 
@@ -225,11 +252,15 @@ Typical use would be to populate an =&opts= element with something like this:
   }
 #+end_src
 
-=comp:empty= produces no completions. It can be used to signal the end of a completion definition sequence when we don't want to repeat the last item.
+*** comp:empty
+
+=comp:empty= produces no completions. It can be used to mark an item in a sequence that should not produce any completions.
 
 #+begin_src elvish
   fn empty { nop }
 #+end_src
+
+*** comp:files
 
 =comp:files= completes filenames, using any typed prefix as the stem. If the =&regex= option is specified, only files matching that pattern are completed. If =&only-dirs= is =$true=, only directories are returned.
 
@@ -266,26 +297,28 @@ Typical use would be to populate an =&opts= element with something like this:
   }
 #+end_src
 
+*** comp:-handler-arity
+
 Determine the arity of a function and return a string representation, for internal use.
 
 #+begin_src elvish
   fn -handler-arity [func]{
     fnargs = [ (count $func[arg-names]) (not-eq $func[rest-arg] '') ]
-    if (eq $fnargs [ 0 $false ]) {
-      put no-args
-    } elif (eq $fnargs [ 1 $false ]) {
-      put one-arg
-    } elif (eq $fnargs [ 0 $true ]) {
-      put rest-arg
-    } else {
-      put other-args
+    if     (eq $fnargs [ 0 $false ]) { put no-args
+    } elif (eq $fnargs [ 1 $false ]) { put one-arg
+    } elif (eq $fnargs [ 0 $true  ]) { put rest-arg
+    } else {                           put other-args
     }
   }
 #+end_src
 
 ** Completion functions
 
-=comp:-expand-item= is the main entry point which expands a "completion definition item" into its completion values. If it's a function, it gets executed with the current element of the command line as a single argument. If it's a list, it's exploded to its elements. If it's a map which contains the =-seq= key, it gets processed with =comp:-expand-sequence=, and if it's a map without the =-seq= key, it gets passed to =comp:-expand-subcommands= (see below for the details of these functions). You can call =comp:-expand-sequence= or =comp:-expand-subcommands= directly if you want, but otherwise =comp:-expand-item= will handle the different structures automatically.
+The backend completion functions =comp:-expand-item=, =comp:-expand-sequence= and =comp:-expand-subcommands= are the ones that actually process the completion definitions and, according to them and the current command line, provide the available completions.
+
+*** comp:-expand-item
+
+=comp:-expand-item=  expands a "completion item" into its completion values. If it's a function, it gets executed with arguments corresponding to its arity; if it's a list, it's exploded to its elements.
 
 #+begin_src elvish
   fn -expand-item [def @cmd]{
@@ -305,13 +338,15 @@ Determine the arity of a function and return a string representation, for intern
   }
 #+end_src
 
-=comp:-expand-sequence= receives a definition map and the current contents of the command line, and uses =edit:complete-getopt= to actually generate the completions. For this, we need to make sure the options and argument handler data structures are in accordance to what =complete-getopt= expects.
+*** comp:-expand-sequence
+
+=comp:-expand-sequence= receives an array of definition items and the current contents of the command line, and uses =edit:complete-getopt= to actually generate the completions. For this, we need to make sure the options and argument handler data structures are in accordance to what =edit:complete-getopt= expects.
 
 #+begin_src elvish
   fn -expand-sequence [seq @cmd &opts=[]]{
 #+end_src
 
-If =$def= contains a key =-opts=, it has to be a list with one element for each command-line option. Element which are maps are assumed to be in the final format (with keys =short=, =long= and =desc=) and used as-is. Elements which are strings are considered as long option names and converted to the appropriate data structure.
+We first preprocess the options. If =&opts= is provided, it has to be a list with one element for each command-line option. Elements that are maps are assumed to be in the final format (with keys =short=, =long= and =desc=) and used as-is (their structure is not checked). Elements which are strings are considered as long option names and converted to the appropriate data structure.
 
 #+begin_src elvish
   final-opts = [(
@@ -325,7 +360,7 @@ If =$def= contains a key =-opts=, it has to be a list with one element for each 
   )]
 #+end_src
 
-We also preprocess the handlers. =edit:complete-getopt= expects each handler to receive only one argument (the current word in the command line), but =comp= allows handlers to receive no arguments, one argument (the current element of the command line) or multiple arguments (the whole command line), so we need to normalize them. Happily, Elvish's functional nature makes this easy by checking the arity of each handler and, if necessary, wrapping them in one-argument functions, but passing them the information they expect.
+We also preprocess the handlers. =edit:complete-getopt= expects each handler to receive only one argument (the current word in the command line), but =comp= allows handlers to receive no arguments, one argument (the current element of the command line) or multiple arguments (the whole command line), so we need to normalize them. Happily, Elvish's functional nature makes this easy by checking the arity of each handler and, if necessary, wrapping them in one-argument functions, but passing them the information they expect. We also wrap items which are arrays into corresponding functions. As a special case, the string ='...'= is also passed, as it is allowed by =edit:complete-getopt= to indicate that the last element needs to be repeated for future elements. Any other handlers are ignored.
 
 #+begin_src elvish
   final-handlers = [(
@@ -353,38 +388,51 @@ Finally, we call =edit:complete-getopt= with the corresponding data structures. 
   }
 #+end_src
 
+*** comp:-expand-subcommands
+
 =comp:-expand-subcommands= receives a definition map and the current contents of the command line.
-
-The algorithm for =comp:-expand-subcommands= is as follows:
-
-1. Scan the current command until the first subcommand is found (i.e. an element which matches an existing key in =$def=), and if found, call =-expand-item= with that definition, and with the command line at that position. We check if the definition is a string, in which case it's expected to be the name of some other command whose definition we need to use (to implement command aliases).
-2. If no subcommand is found, generate a sequence definition which returns the subcommand names for the first position (including any provided options).
-
-This seems backwards from what you would usually expect - I attempted at first multiple variations to expand the subcommands/top-options first, and then only expand the subcommand options and definition from the "tail" handlers, but this doesn't work because of the way =edit:complete-getops= works, the top-level options would get expanded for subcommands as well. This way, we catch the more specific case first (subcommand definition) and only if there's no subcommand in the command line yet, we do the top-level expansion. All with simple and clear code (you wouldn't believe some of the variations I tried while trying to get this to work)
 
 #+begin_src elvish
   fn -expand-subcommands [def @cmd &opts=[]]{
-    subcommands = [(keys $def)]
-    n = (count $cmd)
-    kw = [(range 1 $n | each [i]{
-          if (has-value $subcommands $cmd[$i]) { put $cmd[$i] $i }
-    })]
-    if (and (not-eq $kw []) (not-eq $kw[1] (- $n 1))) {
-      sc sc-pos = $kw[0 1]
-      if (eq (kind-of $def[$sc]) 'string') {
-        cmd[$sc-pos] = $def[$sc]
-        -expand-subcommands &opts=$opts $def $@cmd
-      } else {
-        $def[$sc] (explode $cmd[{$sc-pos}:])
-      }
-    } else {
-      top-def = [ { put $@subcommands } ]
-      -expand-sequence &opts=$opts $top-def $@cmd
-    }
-  }
 #+end_src
 
+The algorithm for =comp:-expand-subcommands= is a bit counterintuitive, this is how it works:
+
+1. Scan the current command to see if a valid subcommand is found (i.e. an element which matches an existing key in =$def=).
+  #+begin_src elvish
+      subcommands = [(keys $def)]
+      n = (count $cmd)
+      kw = [(range 1 $n | each [i]{
+            if (has-value $subcommands $cmd[$i]) { put $cmd[$i] $i }
+      })]
+  #+end_src
+
+2. If a subcommand is found, call its expansion function directly, and with the command line at that position. We check if the definition is a string, in which case it's expected to be the name of some other command whose definition we need to use (to implement command aliases) - we substitute the alias for its target command and call =-expand-subcommands= with the new values.
+  #+begin_src elvish
+      if (and (not-eq $kw []) (not-eq $kw[1] (- $n 1))) {
+        sc sc-pos = $kw[0 1]
+        if (eq (kind-of $def[$sc]) 'string') {
+          cmd[$sc-pos] = $def[$sc]
+          -expand-subcommands &opts=$opts $def $@cmd
+        } else {
+          $def[$sc] (explode $cmd[{$sc-pos}:])
+        }
+  #+end_src
+
+3. If no subcommand is found, generate a sequence definition which returns the subcommand names for the first position (including any provided options).
+  #+begin_src elvish
+      } else {
+        top-def = [ { put $@subcommands } ]
+        -expand-sequence &opts=$opts $top-def $@cmd
+      }
+    }
+  #+end_src
+
+This seems backwards from what one (or at least I) initially expected - I attempted at first multiple variations to expand the subcommands/top-options first, and then only expand the subcommand options and definition from the "tail" handlers, but this doesn't work because of the way =edit:complete-getops= works, the top-level options would get expanded for subcommands as well. This way, we catch the more specific case first (subcommand definition) and only if there's no subcommand in the command line yet, we do the top-level expansion. All with simple and clear code (you wouldn't believe some of the variations I tried while trying to get this to work!).
+
 ** Completion wrapper functions
+
+The wrapper functions are the main entry points - they receive the completion definitions and call the corresponding =-expand-*= function. They also take care of running the pre- and post-hooks, if specified.
 
 #+begin_src elvish
   fn item [item &pre-hook=$nop~ &post-hook=$nop~]{
@@ -395,7 +443,9 @@ This seems backwards from what you would usually expect - I attempted at first m
       put $@result
     }
   }
+#+end_src
 
+#+begin_src elvish
   fn sequence [sequence &opts=[] &pre-hook=$nop~ &post-hook=$nop~]{
     put [@cmd]{
       $pre-hook $@cmd
@@ -404,7 +454,9 @@ This seems backwards from what you would usually expect - I attempted at first m
       put $@result
     }
   }
+#+end_src
 
+#+begin_src elvish
   fn subcommands [def &opts=[] &pre-hook=$nop~ &post-hook=$nop~]{
     put [@cmd]{
       $pre-hook $@cmd

--- a/comp.org
+++ b/comp.org
@@ -299,6 +299,8 @@ Determine the arity of a function and return a string representation, for intern
       put one-arg
     } elif (eq $fnargs [ 0 $true ]) {
       put rest-arg
+    } else {
+      put other-args
     }
   }
 #+end_src
@@ -315,6 +317,7 @@ Determine the arity of a function and return a string representation, for intern
       [ &no-args=  { $def }
         &one-arg=  { $def $arg }
         &rest-arg= { $def $@cmd }
+        &other-args= { put '<completion-fn-arity-error>' }
       ][(-handler-arity $def)]
     } elif (eq $what 'list') {
       explode $def
@@ -354,6 +357,7 @@ We also preprocess the handlers. =edit:complete-getopt= expects each handler to 
             &no-args=  [_]{ $f }
             &one-arg=  $f
             &rest-arg= [_]{ $f $@cmd }
+            &other-args= [_]{ put '<completion-fn-arity-error>' }
           ][(-handler-arity $f)]
         } elif (eq (kind-of $f) 'list') {
           put [_]{ explode $f }
@@ -414,7 +418,7 @@ This seems backwards from what you would usually expect - I attempted at first m
     }
   }
 
-  fn sequence [@sequence &opts=[] &pre-hook=$nop~ &post-hook=$nop~]{
+  fn sequence [sequence &opts=[] &pre-hook=$nop~ &post-hook=$nop~]{
     put [@cmd]{
       $pre-hook $@cmd
       result = [(-expand-sequence &opts=$opts $sequence $@cmd)]

--- a/comp.org
+++ b/comp.org
@@ -37,7 +37,7 @@ From the file where you will define your completions, load this module:
   use github.com/zzamboni/elvish-completions/comp
 #+end_src
 
-The main entry point for this module is =comp:expand=. It receives two arguments:
+The main entry point for this module is =comp:-expand=. It receives two arguments:
 
 - A "completion definition", which in general, indicates how the completions will be produced. See below for details.
 - The contents of the command line so far, as passed to the [[https://elvish.io/ref/edit.html#argument-completer][argument completer functions]].
@@ -48,7 +48,7 @@ This function returns any available completions according to its definition and 
   edit:completion:arg-completer[command] = [@cmd]{ comp:expand $def $@cmd }
 #+end_src
 
-For this common case, =comp= provides a helper function called =comp:expand-wrapper=, which receives only the definition argument and returns a /function/ which can be assigned directly to the corresponding elements of =$edit:completion:arg-completer=, so that the code above can be written like this:
+For this common case, =comp= provides a helper function called =comp:-expand-wrapper=, which receives only the definition argument and returns a /function/ which can be assigned directly to the corresponding elements of =$edit:completion:arg-completer=, so that the code above can be written like this:
 
 #+begin_src elvish
   edit:completion:arg-completer[command] = (comp:expand-wrapper $def)
@@ -69,14 +69,14 @@ The base building block is the "completion definition item", can be one of the f
 
 *Example #1:* a simple completer for =cd=
 
-In this case, we define a function which receives the current "stem" (the part of the filename the user has typed so far) and offers all the relevant files, then filters those which are directories, and returns them as completion possibilities. We pass the function directly as a completion item to =comp:expand=.
+In this case, we define a function which receives the current "stem" (the part of the filename the user has typed so far) and offers all the relevant files, then filters those which are directories, and returns them as completion possibilities. We pass the function directly as a completion item to =comp:-expand=.
 
 #+begin_src elvish
   fn complete-dirs [arg]{ edit:complete-filename $arg | each [x]{ if (-is-dir $x) { put $x } } }
   edit:completion:arg-completer[cd] = [@cmd]{ comp:expand $complete-dirs~ $@cmd }
 #+end_src
 
-I defined the =complete-dirs= function separately only for clarity - you can also embed the lambda directly as an argument to =comp:expand.=
+I defined the =complete-dirs= function separately only for clarity - you can also embed the lambda directly as an argument to =comp:-expand.=
 
 In simple cases like the above, you can use the =comp:expand-wrapper= function to avoid defining the wrapper function by hand:
 
@@ -145,6 +145,16 @@ Completion sequences can be further aggregated into /subcommand structures/ to p
   ]
 
   edit:completion:arg-completer[brew] = (comp:expand-wrapper $brew-completions)
+#+end_src
+
+#+begin_src elvish
+edit:completion:arg-completer[brew] = (comp:subcommands [
+  &install=(comp:sequence { brew search | comp:decorate &style=green } ... \
+            &opts=[(brew install -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()')])
+  &uninstall=(comp:sequence { brew list | comp:decorate &style=red } ... \
+              &opts=[(brew uninstall -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()')])
+  &cat=(comp:sequence { brew search })
+] &opts=[version])
 #+end_src
 
 *Example #6:* a simple completer for a subset of =vagrant=, which receives commands which may have subcommands and options of their own. Note that the value of =&up= is a sequence, but the value of =&box= is a subcommand map which includes the completions for =box add= and =box remove=. Also note the use of the =comp:extract-opts= function to extract the command-line arguments automatically from the help messages.
@@ -252,7 +262,7 @@ Typical use would be to populate an =-opts= element with something like this:
 
 #+begin_src elvish
   fn files [arg &regex='' &dirs-only=$false]{
-    edit:complete-filename $arg | each [x]{
+    put {$arg}*[match-hidden][nomatch-ok] | each [x]{
       if (and (or (not $dirs-only) (-is-dir $x)) (or (eq $regex '') (re:match $regex $x))) {
         put $x
       }
@@ -281,14 +291,14 @@ Typical use would be to populate an =-opts= element with something like this:
 
 ** Completion functions
 
-=comp:expand= is the main entry point which expands a "completion definition item" into its completion values. If it's a function, it gets executed with the current element of the command line as a single argument. If it's a list, it's exploded to its elements. If it's a map which contains the =-seq= key, it gets processed with =comp:sequence=, and if it's a map without the =-seq= key, it gets passed to =comp:subcommands= (see below for the details of these functions). You can call =comp:sequence= or =comp:subcommands= directly if you want, but otherwise =comp:expand= will handle the different structures automatically.
+=comp:-expand= is the main entry point which expands a "completion definition item" into its completion values. If it's a function, it gets executed with the current element of the command line as a single argument. If it's a list, it's exploded to its elements. If it's a map which contains the =-seq= key, it gets processed with =comp:-sequence=, and if it's a map without the =-seq= key, it gets passed to =comp:-subcommands= (see below for the details of these functions). You can call =comp:-sequence= or =comp:-subcommands= directly if you want, but otherwise =comp:-expand= will handle the different structures automatically.
 
 #+begin_src elvish
   # Forward declarations to be overriden later
-  fn sequence { }
-  fn subcommands { }
+  fn -sequence { }
+  fn -subcommands { }
 
-  fn expand [def @cmd]{
+  fn -expand [def @cmd]{
     arg = $cmd[-1]
     what = (kind-of $def)
     if (eq $what 'fn') {
@@ -304,18 +314,18 @@ Typical use would be to populate an =-opts= element with something like this:
       explode $def
     } elif (eq $what 'map') {
       if (has-key $def '-seq') {
-        sequence $def $@cmd
+        -sequence $def $@cmd
       } else {
-        subcommands $def $@cmd
+        -subcommands $def $@cmd
       }
     }
   }
 #+end_src
 
-=comp:sequence= receives a definition map and the current contents of the command line, and uses =edit:complete-getopt= to actually generate the completions. For this, we need to make sure the options and argument handler data structures are in accordance to what =complete-getopt= expects.
+=comp:-sequence= receives a definition map and the current contents of the command line, and uses =edit:complete-getopt= to actually generate the completions. For this, we need to make sure the options and argument handler data structures are in accordance to what =complete-getopt= expects.
 
 #+begin_src elvish
-  sequence~ = [def @cmd]{
+  -sequence~ = [def @cmd]{
 #+end_src
 
 If =$def= contains a key =-opts=, it has to be a list with one element for each command-line option. Element which are maps are assumed to be in the final format (with keys =short=, =long= and =desc=) and used as-is. Elements which are strings are considered as long option names and converted to the appropriate data structure.
@@ -323,7 +333,7 @@ If =$def= contains a key =-opts=, it has to be a list with one element for each 
 #+begin_src elvish
   opts = []
   if (has-key $def -opts) {
-    expand $def[-opts] $@cmd | each [opt]{
+    -expand $def[-opts] $@cmd | each [opt]{
       if (eq (kind-of $opt) map) {
         opts = [ $@opts $opt ]
       } else {
@@ -362,34 +372,36 @@ Finally, we call =edit:complete-getopt= with the corresponding data structures. 
   }
 #+end_src
 
-=comp:subcommands= receives a definition map and the current contents of the command line.
+=comp:-subcommands= receives a definition map and the current contents of the command line.
 
-The algorithm for =comp:subcommands= is as follows:
+The algorithm for =comp:-subcommands= is as follows:
 
-1. Scan the current command until the first subcommand is found (i.e. an element which matches an existing key in =$def=), and if found, call =expand= with that definition, and with the command line at that position. We check if the definition is a string, in which case it's expected to be the name of some other command whose definition we need to use (to implement command aliases).
+1. Scan the current command until the first subcommand is found (i.e. an element which matches an existing key in =$def=), and if found, call =-expand= with that definition, and with the command line at that position. We check if the definition is a string, in which case it's expected to be the name of some other command whose definition we need to use (to implement command aliases).
 2. If no subcommand is found, generate a sequence definition which returns the subcommand names for the first position (including any provided options).
 
 This seems backwards from what you would usually expect - I attempted at first multiple variations to expand the subcommands/top-options first, and then only expand the subcommand options and definition from the "tail" handlers, but this doesn't work because of the way =edit:complete-getops= works, the top-level options would get expanded for subcommands as well. This way, we catch the more specific case first (subcommand definition) and only if there's no subcommand in the command line yet, we do the top-level expansion. All with simple and clear code (you wouldn't believe some of the variations I tried while trying to get this to work)
 
 #+begin_src elvish
-  subcommands~ = [def @cmd]{
+  -subcommands~ = [def @cmd]{
     subcommands = [(keys (dissoc $def -opts))]
-    first-subcommand = [(range 1 (count $cmd) | each [i]{
+    n = (count $cmd)
+    kw = [(range 1 $n | each [i]{
           if (has-value $subcommands $cmd[$i]) { put $cmd[$i] $i }
     })]
-    if (not-eq $first-subcommand []) {
-      subcommand subcommand-pos = $first-subcommand[0 1]
-      if (eq (kind-of $def[$subcommand]) 'string') {
-        subcommands $def (explode $cmd[0:$subcommand-pos]) $def[$subcommand] (explode $cmd[(+ $subcommand-pos 1):])
+    if (and (not-eq $kw []) (not-eq $kw[1] (- $n 1))) {
+      sc sc-pos = $kw[0 1]
+      if (eq (kind-of $def[$sc]) 'string') {
+        cmd[$sc-pos] = $def[$sc]
+        -subcommands $def $@cmd
       } else {
-        expand $def[$subcommand] (explode $cmd[{$subcommand-pos}:])
+        $def[$sc] (explode $cmd[{$sc-pos}:])
       }
     } else {
       top-def = [ &-seq= [ { put $@subcommands }] ]
       if (has-key $def -opts) {
         top-def[-opts] = $def[-opts]
       }
-      sequence $top-def $@cmd
+      -sequence $top-def $@cmd
     }
   }
 #+end_src
@@ -400,12 +412,34 @@ The wrapper functions receive only the =$def= argument, and return a /function/ 
 
 #+begin_src elvish
   fn -wrapper-gen [func]{
-    put [def]{ put [@cmd]{ $func $def $@cmd } }
+    put [def &pre-hook=$nop~ &post-hook=$nop~ &post-filter=$all~]{
+      put [@cmd]{
+        $pre-hook $@cmd
+        result = [($func $def $@cmd)]
+        $post-hook $result $@cmd
+        put $@result
+      }
+    }
   }
 #+end_src
 
 #+begin_src elvish
-  expand-wrapper~ = (-wrapper-gen $expand~)
-  sequence-wrapper~ = (-wrapper-gen $sequence~)
-  subcommands-wrapper~ = (-wrapper-gen $subcommands~)
+  -expand-wrapper~      = (-wrapper-gen $-expand~)
+  -sequence-wrapper~    = (-wrapper-gen $-sequence~)
+  -subcommands-wrapper~ = (-wrapper-gen $-subcommands~)
+#+end_src
+
+#+begin_src elvish
+  fn item [item &pre-hook=$nop~ &post-hook=$nop~]{
+    -expand-wrapper $item &pre-hook=$pre-hook &post-hook=$post-hook
+  }
+
+  fn sequence [@sequence &opts=[] &pre-hook=$nop~ &post-hook=$nop~]{
+    -sequence-wrapper [&-seq=$sequence &-opts=$opts] &pre-hook=$pre-hook &post-hook=$post-hook
+  }
+
+  fn subcommands [def &opts=[] &pre-hook=$nop~ &post-hook=$nop~]{
+    subcmd-map = (assoc $def -opts $opts)
+    -subcommands-wrapper $subcmd-map &pre-hook=$pre-hook &post-hook=$post-hook
+  }
 #+end_src

--- a/comp.org
+++ b/comp.org
@@ -37,7 +37,7 @@ From the file where you will define your completions, load this module:
   use github.com/zzamboni/elvish-completions/comp
 #+end_src
 
-The main entry point for this module is =comp:-expand=. It receives two arguments:
+The main entry point for this module is =comp:-expand-item=. It receives two arguments:
 
 - A "completion definition", which in general, indicates how the completions will be produced. See below for details.
 - The contents of the command line so far, as passed to the [[https://elvish.io/ref/edit.html#argument-completer][argument completer functions]].
@@ -288,102 +288,101 @@ Typical use would be to populate an =-opts= element with something like this:
   }
 #+end_src
 
-
-** Completion functions
-
-=comp:-expand= is the main entry point which expands a "completion definition item" into its completion values. If it's a function, it gets executed with the current element of the command line as a single argument. If it's a list, it's exploded to its elements. If it's a map which contains the =-seq= key, it gets processed with =comp:-sequence=, and if it's a map without the =-seq= key, it gets passed to =comp:-subcommands= (see below for the details of these functions). You can call =comp:-sequence= or =comp:-subcommands= directly if you want, but otherwise =comp:-expand= will handle the different structures automatically.
+Determine the arity of a function and return a string representation, for internal use.
 
 #+begin_src elvish
-  # Forward declarations to be overriden later
-  fn -sequence { }
-  fn -subcommands { }
-
-  fn -expand [def @cmd]{
-    arg = $cmd[-1]
-    what = (kind-of $def)
-    if (eq $what 'fn') {
-      fnargs = [ (count $def[arg-names]) (not-eq $def[rest-arg] '') ]
-      if (eq $fnargs [ 0 $false ]) {
-        $def
-      } elif (eq $fnargs [ 1 $false ]) {
-        $def $arg
-      } elif (eq $fnargs [ 0 $true ]) {
-        $def $@cmd
-      }
-    } elif (eq $what 'list') {
-      explode $def
-    } elif (eq $what 'map') {
-      if (has-key $def '-seq') {
-        -sequence $def $@cmd
-      } else {
-        -subcommands $def $@cmd
-      }
+  fn -handler-arity [func]{
+    fnargs = [ (count $func[arg-names]) (not-eq $func[rest-arg] '') ]
+    if (eq $fnargs [ 0 $false ]) {
+      put no-args
+    } elif (eq $fnargs [ 1 $false ]) {
+      put one-arg
+    } elif (eq $fnargs [ 0 $true ]) {
+      put rest-arg
     }
   }
 #+end_src
 
-=comp:-sequence= receives a definition map and the current contents of the command line, and uses =edit:complete-getopt= to actually generate the completions. For this, we need to make sure the options and argument handler data structures are in accordance to what =complete-getopt= expects.
+** Completion functions
+
+=comp:-expand-item= is the main entry point which expands a "completion definition item" into its completion values. If it's a function, it gets executed with the current element of the command line as a single argument. If it's a list, it's exploded to its elements. If it's a map which contains the =-seq= key, it gets processed with =comp:-expand-sequence=, and if it's a map without the =-seq= key, it gets passed to =comp:-expand-subcommands= (see below for the details of these functions). You can call =comp:-expand-sequence= or =comp:-expand-subcommands= directly if you want, but otherwise =comp:-expand-item= will handle the different structures automatically.
 
 #+begin_src elvish
-  -sequence~ = [def @cmd]{
+  fn -expand-item [def @cmd]{
+    arg = $cmd[-1]
+    what = (kind-of $def)
+    if (eq $what 'fn') {
+      [ &no-args=  { $def }
+        &one-arg=  { $def $arg }
+        &rest-arg= { $def $@cmd }
+      ][(-handler-arity $def)]
+    } elif (eq $what 'list') {
+      explode $def
+    } else {
+      echo (edit:styled "comp:-expand-item: invalid item of type "$what": "(to-string $def) red) >/dev/tty
+    }
+  }
+#+end_src
+
+=comp:-expand-sequence= receives a definition map and the current contents of the command line, and uses =edit:complete-getopt= to actually generate the completions. For this, we need to make sure the options and argument handler data structures are in accordance to what =complete-getopt= expects.
+
+#+begin_src elvish
+  fn -expand-sequence [seq @cmd &opts=[]]{
 #+end_src
 
 If =$def= contains a key =-opts=, it has to be a list with one element for each command-line option. Element which are maps are assumed to be in the final format (with keys =short=, =long= and =desc=) and used as-is. Elements which are strings are considered as long option names and converted to the appropriate data structure.
 
 #+begin_src elvish
-  opts = []
-  if (has-key $def -opts) {
-    -expand $def[-opts] $@cmd | each [opt]{
-      if (eq (kind-of $opt) map) {
-        opts = [ $@opts $opt ]
-      } else {
-        opts = [$@opts [&long= $opt]]
+  final-opts = [(
+      -expand-item $opts $@cmd | each [opt]{
+        if (eq (kind-of $opt) map) {
+          put $opt
+        } else {
+          put [&long= $opt]
+        }
       }
-    }
-  }
+  )]
 #+end_src
 
 We also preprocess the handlers. =edit:complete-getopt= expects each handler to receive only one argument (the current word in the command line), but =comp= allows handlers to receive no arguments, one argument (the current element of the command line) or multiple arguments (the whole command line), so we need to normalize them. Happily, Elvish's functional nature makes this easy by checking the arity of each handler and, if necessary, wrapping them in one-argument functions, but passing them the information they expect.
 
 #+begin_src elvish
-  handlers = []
-  explode $def[-seq] | each [f]{
-    new-f = $f
-    if (eq (kind-of $f) 'fn') {
-      fnargs = [ (count $f[arg-names]) (not-eq $f[rest-arg] '') ]
-      if (eq $fnargs [ 0 $false ]) {
-        new-f = [_]{ $f }
-      } elif (eq $fnargs [ 1 $false ]) {
-        new-f = $f
-      } elif (eq $fnargs [ 0 $true ]) {
-        new-f = [_]{ $f $@cmd }
+  final-handlers = [(
+      explode $seq | each [f]{
+        if (eq (kind-of $f) 'fn') {
+          put [
+            &no-args=  [_]{ $f }
+            &one-arg=  $f
+            &rest-arg= [_]{ $f $@cmd }
+          ][(-handler-arity $f)]
+        } elif (eq (kind-of $f) 'list') {
+          put [_]{ explode $f }
+        } elif (and (eq (kind-of $f) 'string') (eq $f '...')) {
+          put $f
+        }
       }
-    } elif (eq (kind-of $f) 'list') {
-      new-f = [_]{ explode $f }
-    }
-    handlers = [ $@handlers $new-f ]
-  }
+  )]
 #+end_src
 
 Finally, we call =edit:complete-getopt= with the corresponding data structures. It expects the current line /without/ the initial command, so we remove that as well.
 
 #+begin_src elvish
-    edit:complete-getopt $cmd[1:] $opts $handlers
+    edit:complete-getopt $cmd[1:] $final-opts $final-handlers
   }
 #+end_src
 
-=comp:-subcommands= receives a definition map and the current contents of the command line.
+=comp:-expand-subcommands= receives a definition map and the current contents of the command line.
 
-The algorithm for =comp:-subcommands= is as follows:
+The algorithm for =comp:-expand-subcommands= is as follows:
 
-1. Scan the current command until the first subcommand is found (i.e. an element which matches an existing key in =$def=), and if found, call =-expand= with that definition, and with the command line at that position. We check if the definition is a string, in which case it's expected to be the name of some other command whose definition we need to use (to implement command aliases).
+1. Scan the current command until the first subcommand is found (i.e. an element which matches an existing key in =$def=), and if found, call =-expand-item= with that definition, and with the command line at that position. We check if the definition is a string, in which case it's expected to be the name of some other command whose definition we need to use (to implement command aliases).
 2. If no subcommand is found, generate a sequence definition which returns the subcommand names for the first position (including any provided options).
 
 This seems backwards from what you would usually expect - I attempted at first multiple variations to expand the subcommands/top-options first, and then only expand the subcommand options and definition from the "tail" handlers, but this doesn't work because of the way =edit:complete-getops= works, the top-level options would get expanded for subcommands as well. This way, we catch the more specific case first (subcommand definition) and only if there's no subcommand in the command line yet, we do the top-level expansion. All with simple and clear code (you wouldn't believe some of the variations I tried while trying to get this to work)
 
 #+begin_src elvish
-  -subcommands~ = [def @cmd]{
-    subcommands = [(keys (dissoc $def -opts))]
+  fn -expand-subcommands [def @cmd &opts=[]]{
+    subcommands = [(keys $def)]
     n = (count $cmd)
     kw = [(range 1 $n | each [i]{
           if (has-value $subcommands $cmd[$i]) { put $cmd[$i] $i }
@@ -392,54 +391,44 @@ This seems backwards from what you would usually expect - I attempted at first m
       sc sc-pos = $kw[0 1]
       if (eq (kind-of $def[$sc]) 'string') {
         cmd[$sc-pos] = $def[$sc]
-        -subcommands $def $@cmd
+        -expand-subcommands &opts=$opts $def $@cmd
       } else {
         $def[$sc] (explode $cmd[{$sc-pos}:])
       }
     } else {
-      top-def = [ &-seq= [ { put $@subcommands }] ]
-      if (has-key $def -opts) {
-        top-def[-opts] = $def[-opts]
-      }
-      -sequence $top-def $@cmd
+      top-def = [ { put $@subcommands } ]
+      -expand-sequence &opts=$opts $top-def $@cmd
     }
   }
 #+end_src
 
 ** Completion wrapper functions
 
-The wrapper functions receive only the =$def= argument, and return a /function/ which takes the current command and call the corresponding completion function with the correct arguments. We have a wrapper-generator function which takes the function to call and returns the appropriate wrapper function. Very meta.
-
-#+begin_src elvish
-  fn -wrapper-gen [func]{
-    put [def &pre-hook=$nop~ &post-hook=$nop~ &post-filter=$all~]{
-      put [@cmd]{
-        $pre-hook $@cmd
-        result = [($func $def $@cmd)]
-        $post-hook $result $@cmd
-        put $@result
-      }
-    }
-  }
-#+end_src
-
-#+begin_src elvish
-  -expand-wrapper~      = (-wrapper-gen $-expand~)
-  -sequence-wrapper~    = (-wrapper-gen $-sequence~)
-  -subcommands-wrapper~ = (-wrapper-gen $-subcommands~)
-#+end_src
-
 #+begin_src elvish
   fn item [item &pre-hook=$nop~ &post-hook=$nop~]{
-    -expand-wrapper $item &pre-hook=$pre-hook &post-hook=$post-hook
+    put [@cmd]{
+      $pre-hook $@cmd
+      result = [(-expand-item $item $@cmd)]
+      $post-hook $result $@cmd
+      put $@result
+    }
   }
 
   fn sequence [@sequence &opts=[] &pre-hook=$nop~ &post-hook=$nop~]{
-    -sequence-wrapper [&-seq=$sequence &-opts=$opts] &pre-hook=$pre-hook &post-hook=$post-hook
+    put [@cmd]{
+      $pre-hook $@cmd
+      result = [(-expand-sequence &opts=$opts $sequence $@cmd)]
+      $post-hook $result $@cmd
+      put $@result
+    }
   }
 
   fn subcommands [def &opts=[] &pre-hook=$nop~ &post-hook=$nop~]{
-    subcmd-map = (assoc $def -opts $opts)
-    -subcommands-wrapper $subcmd-map &pre-hook=$pre-hook &post-hook=$post-hook
+    put [@cmd]{
+      $pre-hook $@cmd
+      result = [(-expand-subcommands &opts=$opts $def $@cmd)]
+      $post-hook $result $@cmd
+      put $@result
+    }
   }
 #+end_src

--- a/git.elv
+++ b/git.elv
@@ -67,7 +67,7 @@ git help -a | eawk [line @f]{ if (re:match '^  [a-z]' $line) { put $@f } } | eac
   if (eq (kind-of $seq 'string')) {
     completions[$c] = $seq
   } else {
-    completions[$c] = (comp:sequence $@seq &opts={ -git-opts $c })
+    completions[$c] = (comp:sequence $seq &opts={ -git-opts $c })
   }
 }
 
@@ -76,7 +76,7 @@ git config --list | each [l]{ re:find '^alias\.([^=]+)=(.*)$' $l } | each [m]{
   if (has-key $completions $target) {
     completions[$alias] = $target
   } else {
-    completions[$alias] = (comp:sequence)
+    completions[$alias] = (comp:sequence [])
   }
 }
 

--- a/git.elv
+++ b/git.elv
@@ -80,4 +80,6 @@ git config --list | each [l]{ re:find '^alias\.([^=]+)=(.*)$' $l } | each [m]{
   }
 }
 
-edit:completion:arg-completer[git] = (comp:subcommands $completions &pre-hook=[@_]{ status = (git:status) } &opts={ -git-opts })
+edit:completion:arg-completer[git] = (comp:subcommands $completions \
+  &pre-hook=[@_]{ status = (git:status) } &opts={ -git-opts }
+)

--- a/git.org
+++ b/git.org
@@ -121,16 +121,38 @@ We define the functions that return different possible values for completions. T
 
 ** Initialization of completion definitions
 
-In this section we initialize the =$completions= map with the necessary data structure for =comp:expand= to provide the completions. We extract as much information as possible automatically from =git= itself.
+In this section we initialize the =$completions= map with the necessary data structure for =comp:subcommands= to provide the completions. We extract as much information as possible automatically from =git= itself.
 
-First , we fetch the list of valid git commands from the output of =git help -a=. Initially all of them are configured to produce  completions for their options, as extracted by the =-git-opts= function, and no other argument completions. Some of them get assigned more specific completions below.
+First, we store in =$git-completions= the specialized completions for some git commands. As all command sequences are automatically initialized with their respective options below. Each sequence is a list of functions which return the possible completions at that point in the command. The =...= as a last element in some of them indicates that the last completion function is repeated for all further argument positions. The completion can also be a string, in which case it means an alias for some other command.
+
+#+begin_src elvish
+git-completions = [
+  &add=      [ $MOD-UNTRACKED~ ... ]
+  &stage=    add
+  &checkout= [ { MODIFIED; BRANCHES } ... ]
+  &mv=       [ $TRACKED~ ... ]
+  &rm=       [ $TRACKED~ ... ]
+  &diff=     [ { MODIFIED; BRANCHES  } ... ]
+  &push=     [ $REMOTES~ $BRANCHES~ ]
+  &merge=    [ $BRANCHES~ ... ]
+  &init=     [ [stem]{ put "."; comp:files $stem &dirs-only } ]
+  &branch=   [ $BRANCHES~ ... ]
+]
+#+end_src
+
+Next , we fetch the list of valid git commands from the output of =git help -a=, and store the corresponding completion sequences in =$completions=. All of them are configured to produce  completions for their options, as extracted by the =-git-opts= function. Those which have corresponding definitions in =$git-completions= get assigned those.
 
 #+begin_src elvish
   git help -a | eawk [line @f]{ if (re:match '^  [a-z]' $line) { put $@f } } | each [c]{
-    completions[$c] = [
-      &-opts= { -git-opts $c }
-      &-seq= [ ]
-    ]
+    seq = [ ]
+    if (has-key $git-completions $c) {
+      seq = $git-completions[$c]
+    }
+    if (eq (kind-of $seq 'string')) {
+      completions[$c] = $seq
+    } else {
+      completions[$c] = (comp:sequence $@seq &opts={ -git-opts $c })
+    }
   }
 #+end_src
 
@@ -142,43 +164,13 @@ Next, we parse the defined aliases from the output of =git config --list=. We st
     if (has-key $completions $target) {
       completions[$alias] = $target
     } else {
-      completions[$alias] = [ &-seq= [] ]
+      completions[$alias] = (comp:sequence)
     }
-  }
-#+end_src
-
-Now, we add to =$completions= the specialized completions for some git commands. As all command sequences are automatically initialized with their respective options, we only assign new values to the corresponding =-seq= element. Each sequence is a list of functions which return the possible completions at that point in the command. The =...= as a last element in some of them indicates that the last completion function is repeated for all further argument positions.
-
-#+begin_src elvish
-  completions[add][-seq]      = [ $MOD-UNTRACKED~ ... ]
-  completions[stage]          = add
-  completions[checkout][-seq] = [ { MODIFIED; BRANCHES } ... ]
-  completions[mv][-seq]       = [ $TRACKED~ ... ]
-  completions[rm][-seq]       = [ $TRACKED~ ... ]
-  completions[diff][-seq]     = [ { MODIFIED; BRANCHES  } ... ]
-  completions[push][-seq]     = [ $REMOTES~ $BRANCHES~ ]
-  completions[merge][-seq]    = [ $BRANCHES~ ... ]
-  completions[init][-seq]     = [ [stem]{ put "."; comp:files $stem &dirs-only } ]
-  completions[branch][-seq]   = [ $BRANCHES~ ... ]
-#+end_src
-
-We also store in =$completions= the list of global git options, extracted from the output of =git --help=.
-
-#+begin_src elvish
-  completions[-opts] = { -git-opts }
-#+end_src
-
-Finally, we define =git-completer= to simply fetch the current git status information, and call =comp:expand= with out completion definitions.
-
-#+begin_src elvish
-  fn git-completer [gitcmd @rest]{
-    status = (git:status)
-    comp:expand $completions $gitcmd $@rest
   }
 #+end_src
 
 We initialize the completions by assigning the function to the corresponding element of =$edit:completion:arg-completer=. Note that =git:completer= can also be used to complete for other commands which accept git-like commands, such as =vcsh=.
 
 #+begin_src elvish
-  edit:completion:arg-completer[git] = $git-completer~
+  edit:completion:arg-completer[git] = (comp:subcommands $completions &pre-hook=[@_]{ status = (git:status) } &opts={ -git-opts })
 #+end_src

--- a/git.org
+++ b/git.org
@@ -31,6 +31,17 @@ In your =rc.elv=, load this module:
 
 Now you can type =git<space>=, press ~Tab~ and see the corresponding completions. All =git= commands are automatically completed with their options (automatically extracted from their help messages). Some commands get more specific completions, including =add=, =push=, =checkout=, =diff= and a few others. Git aliases are automatically detected as well. Aliases which point to a single =git= command are automatically completed like the original command.
 
+Several components are colorized, you can configure the styles by setting these variables (default values shown):
+
+#+begin_src elvish
+  comp:modified-style = yellow
+  comp:untracked-style = red
+  comp:tracked-style = ''
+  comp:branch-style = blue
+  comp:remote-style = cyan
+#+end_src
+
+
 * Implementation
 :PROPERTIES:
 :header-args:elvish: :tangle (concat (file-name-sans-extension (buffer-file-name)) ".elv")

--- a/git.org
+++ b/git.org
@@ -62,10 +62,14 @@ We store the output of =git:status= in a global variable to make it easier to ac
 
 ** Configuration variables
 
-The =$option-style= variable contains the style to use for command options in the completion menu. Set to =''= (an empty string) to show in the normal style.
+The =$*-style= variables contains the style (as per =edit:styled=) to use for different completion components the completion menu. Set to =''= (an empty string) to show in the normal style.
 
 #+begin_src elvish
-  option-style = gray
+  modified-style = yellow
+  untracked-style = red
+  tracked-style = ''
+  branch-style = blue
+  remote-style = cyan
 #+end_src
 
 ** Utility functions
@@ -108,22 +112,26 @@ The =-git-opts= function receives an optional git command, runs =git [command] -
   }
 #+end_src
 
-We define the functions that return different possible values for completions. These functions assume that =$status= contains already the output from =git:status=, which gets executed by =git-completer= below.
+We define the functions that return different possible values used in the completions. Some of these functions assume that =$status= contains already the output from =git:status=, which gets executed as the pre-hook of the git completer function below.
 
 #+begin_src elvish
-  fn MODIFIED      { explode $status[local-modified] }
-  fn UNTRACKED     { explode $status[untracked] }
+  fn MODIFIED      { explode $status[local-modified] | comp:decorate &style=$modified-style }
+  fn UNTRACKED     { explode $status[untracked] | comp:decorate &style=$untracked-style }
   fn MOD-UNTRACKED { MODIFIED; UNTRACKED }
-  fn TRACKED       { _ = ?(git ls-files 2>/dev/null) }
-  fn BRANCHES      { _ = ?(git branch --list --all --format '%(refname:short)' 2>/dev/null) }
-  fn REMOTES       { _ = ?(git remote 2>/dev/null) }
+  fn TRACKED       { _ = ?(-run-git-cmd git ls-files 2>/dev/null) | comp:decorate &style=$tracked-style }
+  fn BRANCHES      [&all=$false]{
+    -allarg = []
+    if $all { -allarg = ['--all'] }
+    _ = ?(-run-git-cmd git branch --list (explode $-allarg) --format '%(refname:short)' 2>/dev/null |
+  comp:decorate &display-suffix=' (branch)' &style=$branch-style) }
+  fn REMOTES       { _ = ?(-run-git-cmd git remote 2>/dev/null | comp:decorate &style=$remote-style ) }
 #+end_src
 
 ** Initialization of completion definitions
 
 In this section we initialize the =$completions= map with the necessary data structure for =comp:subcommands= to provide the completions. We extract as much information as possible automatically from =git= itself.
 
-First, we store in =$git-completions= the specialized completions for some git commands. As all command sequences are automatically initialized with their respective options below. Each sequence is a list of functions which return the possible completions at that point in the command. The =...= as a last element in some of them indicates that the last completion function is repeated for all further argument positions. The completion can also be a string, in which case it means an alias for some other command.
+First, we store in =$git-completions= the specialized completions for some git commands. Each sequence is a list of functions which return the possible completions at that point in the command. The =...= as a last element in some of them indicates that the last completion function is repeated for all further argument positions. The completion can also be a string, in which case it means an alias for some other command.
 
 #+begin_src elvish
 git-completions = [
@@ -133,7 +141,7 @@ git-completions = [
   &mv=       [ $TRACKED~ ... ]
   &rm=       [ $TRACKED~ ... ]
   &diff=     [ { MODIFIED; BRANCHES  } ... ]
-  &push=     [ $REMOTES~ $BRANCHES~ ]
+  &push=     [ $REMOTES~ { BRANCHES &all } ]
   &merge=    [ $BRANCHES~ ... ]
   &init=     [ [stem]{ put "."; comp:files $stem &dirs-only } ]
   &branch=   [ $BRANCHES~ ... ]
@@ -156,7 +164,7 @@ Next , we fetch the list of valid git commands from the output of =git help -a=,
   }
 #+end_src
 
-Next, we parse the defined aliases from the output of =git config --list=. We store the aliases in =completions= as well, but we check if an alias points to another valid command. In this case, we store the name of the target command as its value, which =comp:expand= interprets as "use the completions from the target command".
+Next, we parse the defined aliases from the output of =git config --list=. We store the aliases in =completions= as well, but we check if an alias points to another valid command. In this case, we store the name of the target command as its value, which =comp:expand= interprets as "use the completions from the target command". If an alias does not expand to another existing command, we set up its completions as empty.
 
 #+begin_src elvish
   git config --list | each [l]{ re:find '^alias\.([^=]+)=(.*)$' $l } | each [m]{
@@ -169,7 +177,7 @@ Next, we parse the defined aliases from the output of =git config --list=. We st
   }
 #+end_src
 
-We initialize the completions by assigning the function to the corresponding element of =$edit:completion:arg-completer=. Note that =git:completer= can also be used to complete for other commands which accept git-like commands, such as =vcsh=.
+We setup the completer by assigning the function to the corresponding element of =$edit:completion:arg-completer=.
 
 #+begin_src elvish
   edit:completion:arg-completer[git] = (comp:subcommands $completions \

--- a/git.org
+++ b/git.org
@@ -172,5 +172,7 @@ Next, we parse the defined aliases from the output of =git config --list=. We st
 We initialize the completions by assigning the function to the corresponding element of =$edit:completion:arg-completer=. Note that =git:completer= can also be used to complete for other commands which accept git-like commands, such as =vcsh=.
 
 #+begin_src elvish
-  edit:completion:arg-completer[git] = (comp:subcommands $completions &pre-hook=[@_]{ status = (git:status) } &opts={ -git-opts })
+  edit:completion:arg-completer[git] = (comp:subcommands $completions \
+    &pre-hook=[@_]{ status = (git:status) } &opts={ -git-opts }
+  )
 #+end_src

--- a/git.org
+++ b/git.org
@@ -151,7 +151,7 @@ Next , we fetch the list of valid git commands from the output of =git help -a=,
     if (eq (kind-of $seq 'string')) {
       completions[$c] = $seq
     } else {
-      completions[$c] = (comp:sequence $@seq &opts={ -git-opts $c })
+      completions[$c] = (comp:sequence $seq &opts={ -git-opts $c })
     }
   }
 #+end_src
@@ -164,7 +164,7 @@ Next, we parse the defined aliases from the output of =git config --list=. We st
     if (has-key $completions $target) {
       completions[$alias] = $target
     } else {
-      completions[$alias] = (comp:sequence)
+      completions[$alias] = (comp:sequence [])
     }
   }
 #+end_src

--- a/ssh.elv
+++ b/ssh.elv
@@ -24,13 +24,13 @@ fn -ssh-hosts {
 ssh-opts = [ [ &short= o ] ]
 
 fn -gen-ssh-completions [&suffix='']{
-  put [@cmd]{
-    if (eq $cmd[-2] "-o") {
-      explode $-ssh-options
-    } else {
-      -ssh-hosts | comp:decorate &suffix=$suffix
-    }
-  } ...
+  put [ [@cmd]{
+      if (eq $cmd[-2] "-o") {
+        explode $-ssh-options
+      } else {
+        -ssh-hosts | comp:decorate &suffix=$suffix
+      }
+  } ... ]
 }
 
 edit:completion:arg-completer[ssh]  = (comp:sequence &opts=$ssh-opts (-gen-ssh-completions))

--- a/ssh.elv
+++ b/ssh.elv
@@ -21,24 +21,18 @@ fn -ssh-hosts {
     comp:decorate &suffix='='
 )]
 
-fn -gen-completions [&suffix='']{
-  put [
-    &-opts= [ [ &short= o ] ]
-    &-seq= [ [@cmd]{
-        if (eq $cmd[-2] "-o") {
-          explode $-ssh-options
-        } else {
-          -ssh-hosts | comp:decorate &suffix=$suffix
-        }
-      }
-      ...
-    ]
-  ]
+ssh-opts = [ [ &short= o ] ]
+
+fn -gen-ssh-completions [&suffix='']{
+  put [@cmd]{
+    if (eq $cmd[-2] "-o") {
+      explode $-ssh-options
+    } else {
+      -ssh-hosts | comp:decorate &suffix=$suffix
+    }
+  } ...
 }
 
-completions-ssh = (-gen-completions)
-completions-scp = (-gen-completions &suffix=":")
-
-edit:completion:arg-completer[ssh]  = (comp:expand-wrapper $completions-ssh)
-edit:completion:arg-completer[sftp] = (comp:expand-wrapper $completions-ssh)
-edit:completion:arg-completer[scp]  = (comp:expand-wrapper $completions-scp)
+edit:completion:arg-completer[ssh]  = (comp:sequence &opts=$ssh-opts (-gen-ssh-completions))
+edit:completion:arg-completer[sftp] = (comp:sequence &opts=$ssh-opts (-gen-ssh-completions))
+edit:completion:arg-completer[scp]  = (comp:sequence &opts=$ssh-opts (-gen-ssh-completions &suffix=":"))

--- a/ssh.org
+++ b/ssh.org
@@ -107,13 +107,13 @@ We store in =-ssh-options= all the possible configuration options, by parsing th
   ssh-opts = [ [ &short= o ] ]
 
   fn -gen-ssh-completions [&suffix='']{
-    put [@cmd]{
-      if (eq $cmd[-2] "-o") {
-        explode $-ssh-options
-      } else {
-        -ssh-hosts | comp:decorate &suffix=$suffix
-      }
-    } ...
+    put [ [@cmd]{
+        if (eq $cmd[-2] "-o") {
+          explode $-ssh-options
+        } else {
+          -ssh-hosts | comp:decorate &suffix=$suffix
+        }
+    } ... ]
   }
 #+end_src
 

--- a/ssh.org
+++ b/ssh.org
@@ -104,33 +104,25 @@ We store in =-ssh-options= all the possible configuration options, by parsing th
 =-gen-completions= dynamically generates the completion definition for ssh-related commands. We use this because the completions for =ssh= and =scp=, for example, are the same except for the suffix that needs to be added to the hostnames in the completion. The completion definition in all cases provides either the list of valid options (if the previous argument is =-o=, or otherwise =-o= plus the list of hosts (with the appropriate suffix).
 
 #+begin_src elvish
-  fn -gen-completions [&suffix='']{
-    put [
-      &-opts= [ [ &short= o ] ]
-      &-seq= [ [@cmd]{
-          if (eq $cmd[-2] "-o") {
-            explode $-ssh-options
-          } else {
-            -ssh-hosts | comp:decorate &suffix=$suffix
-          }
-        }
-        ...
-      ]
-    ]
+  ssh-opts = [ [ &short= o ] ]
+
+  fn -gen-ssh-completions [&suffix='']{
+    put [@cmd]{
+      if (eq $cmd[-2] "-o") {
+        explode $-ssh-options
+      } else {
+        -ssh-hosts | comp:decorate &suffix=$suffix
+      }
+    } ...
   }
 #+end_src
 
 We use =-gen-completions= to produce the actual completion definitions for =ssh= and =scp=.
 
-#+begin_src elvish
-  completions-ssh = (-gen-completions)
-  completions-scp = (-gen-completions &suffix=":")
-#+end_src
-
 We initialize the completions by using =comp:expand-wrapper= to produce the functions with the corresponding definition and assign them to the corresponding elements of =$edit:completion:arg-completer=.
 
 #+begin_src elvish
-  edit:completion:arg-completer[ssh]  = (comp:expand-wrapper $completions-ssh)
-  edit:completion:arg-completer[sftp] = (comp:expand-wrapper $completions-ssh)
-  edit:completion:arg-completer[scp]  = (comp:expand-wrapper $completions-scp)
+  edit:completion:arg-completer[ssh]  = (comp:sequence &opts=$ssh-opts (-gen-ssh-completions))
+  edit:completion:arg-completer[sftp] = (comp:sequence &opts=$ssh-opts (-gen-ssh-completions))
+  edit:completion:arg-completer[scp]  = (comp:sequence &opts=$ssh-opts (-gen-ssh-completions &suffix=":"))
 #+end_src


### PR DESCRIPTION
This branch is to develop and test the ideas for an API redesign for the `comp` framework, originally proposed by @xiaq in #6. I'm including the description here for reference:

> One note on the API design: I think it will be much cleaner if you organize the API around completer, and offer the *-wrapper functions as a first-class interface. Right now you have the `expand` command peek into the shape of `$def` to determine what kind of completer to generate: using your example of `brew`:
> 
> ```
> brew-completions = [
>   &-opts= [ version ]
>   &install= [
>     &-opts= [ (brew install -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()') ]
>     &-seq= [ { brew search | comp:decorate &style=green } ... ]
>   ]
>   &uninstall= [
>     &-opts= [ (brew uninstall -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()') ]
>     &-seq= [ { brew list | comp:decorate &style=red } ... ]
>   ]
>   &cat= [ &-seq= [ { brew search } ] ]
> ]
> 
> edit:completion:arg-completer[brew] = (comp:expand-wrapper $brew-completions)
> ```
> 
> Basically you are building a DSL with Elvish lists and maps. This is fine for now, but functions can encode information more flexibly and don't require explicit parsing.
> 
> ```
> edit:completion:arg-completer[brew] = (comp:subcommands [
>   &install=(comp:sequence { brew search | comp:decorate &style=green } ... \
>             &opts=[(brew install -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()')])
>   &uninstall=(comp:sequence { brew list | comp:decorate &style=red } ... \
>               &opts=[(brew uninstall -h | take 1 | comp:extract-opts &regex='()--(\w[\w-]*)()')]
>   &cat=(comp:sequence { brew search })
> ] &opts=[version])
> ```
> 
> This incorporates several ideas:
> 
> * The commands `comp:subcommands` and `comp:sequence` now both output a completer (like their `-wrapper` counterparts in your version)
> 
> * `comp:subcommands` accepts the subcommand completer map as the argument, and the option map as an option.
> 
> * `comp:sequence` accepts the argument completers as arguments, and the option map as an option.