### PR TITLE
Some refinements in Option argument completion

### DIFF
--- a/comp.elv
+++ b/comp.elv
@@ -31,7 +31,7 @@ fn dirs [arg &regex='']{
 
 fn extract-opts [@cmd
   &regex='^\s*(?:-(\w),?\s*)?(?:--?([\w-]+))?(?:\[=(\S+)\]|[ =](\S+))?\s*?\s\s(\w.*)$'
-  &regex-map=[&short=1 &long=2 &arg-optional=3 &arg-mandatory=4 &desc=5]
+  &regex-map=[&short=1 &long=2 &arg-optional=3 &arg-required=4 &desc=5]
   &fold=$false
 ]{
   -line = ''
@@ -55,7 +55,7 @@ fn extract-opts [@cmd
       if (has-key $g $regex-map[$k]) {
         field = $g[$regex-map[$k]][text]
         if (not-eq $field '') {
-          if (has-value [arg-optional arg-mandatory] $k) {
+          if (has-value [arg-optional arg-required] $k) {
             opt[$k] = $true
             opt[arg-desc] = $field
           } else {

--- a/comp.elv
+++ b/comp.elv
@@ -100,32 +100,15 @@ fn -expand-sequence [seq @cmd &opts=[]]{
 final-opts = [(
     -expand-item $opts $@cmd | each [opt]{
       if (eq (kind-of $opt) map) {
+        if (has-key $opt arg-completer) {
+          opt[completer] = [_]{ -expand-item $opt[arg-completer] $@cmd }
+        }
         put $opt
       } else {
         put [&long= $opt]
       }
     }
 )]
-
-fn -has-and-is [def opt]{
-  or (and (has-key $def short) (eq '-'$def[short] $opt)) (and (has-key $def long) (eq '--'$def[long] $opt))
-}
-
-if (>= (count $cmd) 3) {
-  prev-opt = [&]
-  prev-word = $cmd[-2]
-  each [o]{
-    if (-has-and-is $o $prev-word) {
-      prev-opt = $o
-    }
-  } $final-opts
-  if (and (not-eq $prev-opt [&]) (has-key $prev-opt arg-completer)) {
-    -expand-item $prev-opt[arg-completer] $@cmd
-    if (and (has-key $prev-opt arg-required) $prev-opt[arg-required]) {
-      return
-    }
-  }
-}
 
 final-handlers = [(
     explode $seq | each [f]{

--- a/comp.org
+++ b/comp.org
@@ -109,7 +109,7 @@ If the =&opts= option is passed to the =comp:sequence= function, it must contain
     - =short= for the short one-letter option;
     - =long= for the long-option string;
     - =desc= for a descriptive string which gets shown in the completion menu;
-    - =arg-mandatory= or =arg-optional=: either one but not both can be set to =$true= to indicate whether the option takes a mandatory or optional argument;
+    - =arg-required= or =arg-optional=: either one but not both can be set to =$true= to indicate whether the option takes a mandatory or optional argument;
     - =arg-completer= can be specified and contain a completion item as described in [[*Items][Items]], and which will be expanded to provide completions for that argument's values.
 
 Simple example of a completion data structure for option =-t= (long form =--type=), which has a mandatory argument which can be =elv=, =org= or =txt=:
@@ -118,7 +118,7 @@ Simple example of a completion data structure for option =-t= (long form =--type
   [ &short=t
     &long=type
     &desc="Type of file to show"
-    &arg-mandatory=$true
+    &arg-required=$true
     &arg-completer= [ elv org txt ]
   ]
 #+end_example
@@ -226,10 +226,10 @@ The regular expression used to extract the options can be specified with the =&r
 The mapping of capture groups from the regex to option components is defined by the =&regex-map= option. Its default value (which also shows the available fields) is:
 
 #+begin_src elvish :noweb-ref opt-capture-map
-    &regex-map=[&short=1 &long=2 &arg-optional=3 &arg-mandatory=4 &desc=5]
+    &regex-map=[&short=1 &long=2 &arg-optional=3 &arg-requested=4 &desc=5]
 #+end_src
 
-At least one of =short= or =long= must be present in =regex-map=. The =arg-optional= and =arg-mandatory= groups, if present, are handled specially: if any of them is not empty, then its contents is stored as =arg-desc= in the output, and the corresponding =arg-mandatory= / =arg-optional= is set to =$true=.
+At least one of =short= or =long= must be present in =regex-map=. The =arg-optional= and =arg-required= groups, if present, are handled specially: if any of them is not empty, then its contents is stored as =arg-desc= in the output, and the corresponding =arg-required= / =arg-optional= is set to =$true=.
 
 If =&fold= is =$true=, then the input is preprocessed to join option descriptions which span more than one line (the heuristic is not perfect and may not work in all cases, also for now it only joins one line after the option).
 
@@ -239,7 +239,7 @@ If =&fold= is =$true=, then the input is preprocessed to join option description
   brew-completions = [
     &install= (comp:sequence \
       &opts= [(brew install -h | take 1 |
-          comp:extract-opts &regex='--(\w[\w-]*)(?:=(.*?)\])?' &regex-map=[&long=1 &arg-mandatory=2]
+          comp:extract-opts &regex='--(\w[\w-]*)(?:=(.*?)\])?' &regex-map=[&long=1 &arg-required=2]
       )]  \
       [ { brew search | comp:decorate &style=green } ... ]
     )
@@ -322,7 +322,7 @@ We start by loading some basic modules we need.
 
 *** comp:extract-opts
 
-=comp:extract-opts= takes input from the pipeline and parses it using a regular expression. The default regex contains 5 groups to parse the =short=, =long=, =arg-mandatory=, =arg-optional= and =desc=, but both the regex and the mapping can be configured using the =&regex= and =&regex-map= options. At last one of short/long is mandatory, everything else is optional. Returns an option map with all existing keys, depending on the available groups and the keys in =$regex-map=. Only produces an output if at least =short= or =long= has a value. The =arg-optional= and =arg-mandatory= groups, if present, are handled specially: if any of them is not empty, then its contents is stored as =arg-desc= in the output, and the corresponding =arg-mandatory= / =arg-optional= is set to =$true=.
+=comp:extract-opts= takes input from the pipeline and parses it using a regular expression. The default regex contains 5 groups to parse the =short=, =long=, =arg-required=, =arg-optional= and =desc=, but both the regex and the mapping can be configured using the =&regex= and =&regex-map= options. At last one of short/long is mandatory, everything else is optional. Returns an option map with all existing keys, depending on the available groups and the keys in =$regex-map=. Only produces an output if at least =short= or =long= has a value. The =arg-optional= and =arg-required= groups, if present, are handled specially: if any of them is not empty, then its contents is stored as =arg-desc= in the output, and the corresponding =arg-required= / =arg-optional= is set to =$true=.
 
 If =&fold= is =$true=, then the input is preprocessed to join option descriptions which span more than one line (the heuristic is not perfect and may not work in all cases, also for now it only joins one line after the option).
 
@@ -353,7 +353,7 @@ If =&fold= is =$true=, then the input is preprocessed to join option description
         if (has-key $g $regex-map[$k]) {
           field = $g[$regex-map[$k]][text]
           if (not-eq $field '') {
-            if (has-value [arg-optional arg-mandatory] $k) {
+            if (has-value [arg-optional arg-required] $k) {
               opt[$k] = $true
               opt[arg-desc] = $field
             } else {
@@ -418,7 +418,7 @@ The backend completion functions =comp:-expand-item=, =comp:-expand-sequence= an
   fn -expand-sequence [seq @cmd &opts=[]]{
 #+end_src
 
-We first preprocess the options. If =&opts= is provided, it has to be a completion item which expands to a list with one element per option. Elements that are maps are assumed to be in getopt format (with keys =short=, =long=, =desc=, =arg-mandatory=, =arg-optional= and =arg-desc=) and used as-is (their structure is not checked). Elements which are strings are considered as long option names and converted to the appropriate data structure.
+We first preprocess the options. If =&opts= is provided, it has to be a completion item which expands to a list with one element per option. Elements that are maps are assumed to be in getopt format (with keys =short=, =long=, =desc=, =arg-required=, =arg-optional= and =arg-desc=) and used as-is (their structure is not checked). Elements which are strings are considered as long option names and converted to the appropriate data structure.
 
 #+begin_src elvish
   final-opts = [(

--- a/comp.org
+++ b/comp.org
@@ -420,10 +420,15 @@ The backend completion functions =comp:-expand-item=, =comp:-expand-sequence= an
 
 We first preprocess the options. If =&opts= is provided, it has to be a completion item which expands to a list with one element per option. Elements that are maps are assumed to be in getopt format (with keys =short=, =long=, =desc=, =arg-required=, =arg-optional= and =arg-desc=) and used as-is (their structure is not checked). Elements which are strings are considered as long option names and converted to the appropriate data structure.
 
+Because =edit:complete-getopt= support option argument completion with key =completer=. So if option structure has an =arg-completer= key, then it is expanded as an completion item and offers as a completer.
+
 #+begin_src elvish
   final-opts = [(
       -expand-item $opts $@cmd | each [opt]{
         if (eq (kind-of $opt) map) {
+          if (has-key $opt arg-completer) {
+            opt[completer] = [_]{ -expand-item $opt[arg-completer] $@cmd }
+          }
           put $opt
         } else {
           put [&long= $opt]
@@ -431,31 +436,6 @@ We first preprocess the options. If =&opts= is provided, it has to be a completi
       }
   )]
 #+end_src
-
-To allow specifying completers for option arguments, we check if the previous component of the command line is an existing option. If so, and if the option structure has an =arg-completer= key, then it is expanded as a completion item and offered as completions. If the option definition has the =arg-required= key, then no other completions are offered, otherwise the code falls through to the argument handlers, which means the completions for the first argument handler would also be produced.
-
-#+begin_src elvish
-  fn -has-and-is [def opt]{
-    or (and (has-key $def short) (eq '-'$def[short] $opt)) (and (has-key $def long) (eq '--'$def[long] $opt))
-  }
-
-  if (>= (count $cmd) 3) {
-    prev-opt = [&]
-    prev-word = $cmd[-2]
-    each [o]{
-      if (-has-and-is $o $prev-word) {
-        prev-opt = $o
-      }
-    } $final-opts
-    if (and (not-eq $prev-opt [&]) (has-key $prev-opt arg-completer)) {
-      -expand-item $prev-opt[arg-completer] $@cmd
-      if (and (has-key $prev-opt arg-required) $prev-opt[arg-required]) {
-        return
-      }
-    }
-  }
-#+end_src
-
 
 We also preprocess the handlers. =edit:complete-getopt= expects each handler to receive only one argument (the current word in the command line), but =comp= allows handlers to receive no arguments, one argument (the current element of the command line) or multiple arguments (the whole command line), so we need to normalize them. Happily, Elvish's functional nature makes this easy by checking the arity of each handler and, if necessary, wrapping them in one-argument functions, but passing them the information they expect. We also wrap items which are arrays into corresponding functions. As a special case, the string ='...'= is also passed, as it is allowed by =edit:complete-getopt= to indicate that the last element needs to be repeated for future elements. Any other handlers are ignored.
 

--- a/git.elv
+++ b/git.elv
@@ -80,11 +80,11 @@ git-completions = [
                       [&short=q &long=quiet]
                       [&short=u &long=include-untracked]
                       [&short=a &long=all]
-                      [&short=m &long=message &arg-mandatory &arg-required]
+                      [&short=m &long=message &arg-required]
                     ])
                     &create= (comp:sequence [])
                     &store= (comp:sequence [ $BRANCHES~ ] &opts=[
-                      [&short=m &long=message &arg-mandatory &arg-required]
+                      [&short=m &long=message &arg-required]
                       [&short=q &long=quiet]
                     ])
                   ]


### PR DESCRIPTION
This patch set does following two things:

- `arg-mandatory` has been replaced by `arg-required`, let's align with it.
- simplify `comp:-expand-sequence` by leveraging option's completer.