### PR TITLE
Add completion for `ssh -i/--inventory` option

### DIFF
--- a/ssh.elv
+++ b/ssh.elv
@@ -32,6 +32,11 @@ ssh-opts = [
     &arg-required= $true
     &arg-completer= $-gen-ssh-options~
   ]
+  [ &short= i
+    &long= inventory
+    &arg-required= $true
+    &arg-completer= $comp:files~
+  ]
 ]
 
 fn -ssh-host-completions [arg &suffix='']{

--- a/ssh.org
+++ b/ssh.org
@@ -108,12 +108,21 @@ We store in =-ssh-options= all the possible configuration options, by parsing th
   }
 #+end_src
 
-The =$ssh-opts= array stores the definitions of command-line options. For now we only complete =-o=, including completions for its argument, generated with =-gen-ssh-options= defined above.
+The =$ssh-opts= array stores the definitions of command-line options. For now we only complete:
+
+  - =-o= (including completions for its argument) generated with =-gen-ssh-options= defined above
+  - =-i/--inventory= generated with =comp:files= defined in =comp.elv=
+
 #+begin_src elvish
   ssh-opts = [
     [ &short= o
       &arg-required= $true
       &arg-completer= $-gen-ssh-options~
+    ]
+    [ &short= i
+      &long= inventory
+      &arg-required= $true
+      &arg-completer= $comp:files~
     ]
   ]
 #+end_src


### PR DESCRIPTION
This diff extends completion for `ssh` to include file completion for the `-i/--inventory`.