### PR TITLE
Remove &style parameter to edit:complex-candidate

### DIFF
--- a/comp.elv
+++ b/comp.elv
@@ -2,6 +2,7 @@ use re
 use github.com/zzamboni/elvish-modules/util
 
 fn decorate [@input &code-suffix='' &display-suffix='' &suffix='' &style='']{
+  # &style is currently ignored because it is not supported by Elvish
   if (eq (count $input) 0) {
     input = [(all)]
   }
@@ -10,7 +11,7 @@ fn decorate [@input &code-suffix='' &display-suffix='' &suffix='' &style='']{
     code-suffix = $suffix
   }
   each [k]{
-    edit:complex-candidate &code-suffix=$code-suffix &display-suffix=$display-suffix &style=$style $k
+    edit:complex-candidate &code-suffix=$code-suffix &display-suffix=$display-suffix $k
   } $input
 }
 

--- a/comp.org
+++ b/comp.org
@@ -196,11 +196,11 @@ Finally, completion sequences can be aggregated into /subcommand structures/ tog
 
 #+begin_src elvish
 > comp:decorate &suffix=":" foo bar
-▶ (edit:complex-candidate foo &code-suffix=: &display-suffix=: &style='')
-▶ (edit:complex-candidate bar &code-suffix=: &display-suffix=: &style='')
+▶ (edit:complex-candidate foo &code-suffix=: &display-suffix=: )
+▶ (edit:complex-candidate bar &code-suffix=: &display-suffix=: )
 > put foo bar | comp:decorate &style="red"
-▶ (edit:complex-candidate foo &code-suffix='' &display-suffix='' &style=31)
-▶ (edit:complex-candidate bar &code-suffix='' &display-suffix='' &style=31)
+▶ (edit:complex-candidate foo &code-suffix='' &display-suffix='')
+▶ (edit:complex-candidate bar &code-suffix='' &display-suffix='')
 #+end_src
 
 =comp:extract-opts= takes input from the pipeline and extracts command-line option data structures from its output. By default it understand the following common formats:
@@ -276,6 +276,7 @@ We start by loading some basic modules we need.
 
 #+begin_src elvish
   fn decorate [@input &code-suffix='' &display-suffix='' &suffix='' &style='']{
+    # &style is currently ignored because it is not supported by Elvish
     if (eq (count $input) 0) {
       input = [(all)]
     }
@@ -284,7 +285,7 @@ We start by loading some basic modules we need.
       code-suffix = $suffix
     }
     each [k]{
-      edit:complex-candidate &code-suffix=$code-suffix &display-suffix=$display-suffix &style=$style $k
+      edit:complex-candidate &code-suffix=$code-suffix &display-suffix=$display-suffix $k
     } $input
   }
 #+end_src


### PR DESCRIPTION
I don't know when it changed and I didn't find the commit, but the elvish-completions stopped working for me recently and I traced it back to `edit:complex-candidate` throwing an exception when given the `&style` parameter. (Apparently the parameter was previously ignored, because I can't find support for it in the codebase.)