### PR TITLE
Add support for git switch

### DIFF
--- a/git.org
+++ b/git.org
@@ -142,11 +142,19 @@ We define the functions that return different possible values used in the comple
   fn UNMERGED      { all $status[unmerged] | comp:decorate &style=$unmerged-style }
   fn MOD-UNTRACKED { MODIFIED; UNTRACKED }
   fn TRACKED       { _ = ?(-run-git ls-files 2>&-) | comp:decorate &style=$tracked-style }
-  fn BRANCHES      [&all=$false]{
+  fn BRANCHES      [&all=$false &branch=$true]{
     -allarg = []
+    -branch = ''
     if $all { -allarg = ['--all'] }
+    if $branch { -branch = ' (branch)' }
     _ = ?(-run-git branch --list (all $-allarg) --format '%(refname:short)' 2>&- |
-    comp:decorate &display-suffix=' (branch)' &style=$branch-style)
+    comp:decorate &display-suffix=$-branch &style=$branch-style)
+  }
+  fn REMOTE-BRANCHES {
+    _ = ?(-run-git branch --list --remote --format '%(refname:short)' 2>&- |
+    grep -v HEAD |
+    each [branch]{ re:replace 'origin/' '' $branch } |
+    comp:decorate &display-suffix=' (remote branch)' &style=$branch-style)
   }
   fn REMOTES       { _ = ?(-run-git remote 2>&- | comp:decorate &display-suffix=' (remote)' &style=$remote-style ) }
   fn STASHES       { _ = ?(-run-git stash list 2>&- | each [l]{ put [(re:split : $l)][0] } ) }
@@ -161,6 +169,7 @@ We define the functions that return different possible values used in the comple
     &add=           [ [stem]{ MOD-UNTRACKED; UNMERGED; comp:dirs $stem } ... ]
     &stage=         add
     &checkout=      [ { MODIFIED; BRANCHES } ... ]
+    &switch=        [ { $BRANCHES~ &branch=$false; REMOTE-BRANCHES } ]
     &mv=            [ [stem]{ TRACKED; comp:dirs $stem } ... ]
     &rm=            [ [stem]{ TRACKED; comp:dirs $stem } ... ]
     &diff=          [ { MODIFIED; BRANCHES  } ... ]


### PR DESCRIPTION
Closes #14 (finally!).

Specifically, this now enables tab completion for local & remote branches when using `git switch`. Any remote branches will be tagged with a `(remote)` in the completion listing. The `BRANCHES` function was modified to optionally include the `(branch)` suffix since with `git switch` you're only dealing with branches, not local files. Behavior of `git checkout` was left unmodified.

I'm not sure if I did the orgmode stuff right. Feel free to fix yourself or tell me what I might have done wrong.