### PR TITLE
Use '==' for numerical comparison

### DIFF
--- a/comp.elv
+++ b/comp.elv
@@ -4,7 +4,7 @@ use github.com/zzamboni/elvish-modules/util
 
 fn decorate [@input &code-suffix='' &display-suffix='' &suffix='' &style='']{
   # &style is currently ignored because it is not supported by Elvish
-  if (eq (count $input) 0) {
+  if (== (count $input) 0) {
     input = [(all)]
   }
   if (not-eq $suffix '') {


### PR DESCRIPTION
Apparently in some recent update `count` started to output [typed numbers](https://elv.sh/ref/builtin.html#num), which are not `eq` to their stringy equivalents anymore.