### PR TITLE
Updated all modules for v0.17 syntax, removing all deprecated syntax

### DIFF
--- a/builtins.elv
+++ b/builtins.elv
@@ -3,20 +3,20 @@ use re
 use path
 use str
 
-edit:completion:arg-completer[use] = (
+set edit:completion:arg-completer[use] = (
   comp:sequence [
-    [stem]{
+    {|stem|
       if (not (str:has-prefix $stem '.')) {
         put './' '../'
-        put ~/.elvish/lib/**[nomatch-ok].elv | each [m]{
+        put ~/.elvish/lib/**[nomatch-ok].elv | each {|m|
           if (not (path:is-dir $m)) {
             re:replace ~/.elvish/lib/'(.*).elv' '$1' $m
           }
         }
       } else {
-        if (eq $stem ".") { stem = "./" }
-        if (eq $stem "..") { stem = "../" }
-        comp:files $stem &regex='.*\.elv' &transform=[s]{ re:replace '\.elv$' '' $s }
+        if (eq $stem ".") { set stem = "./" }
+        if (eq $stem "..") { set stem = "../" }
+        comp:files $stem &regex='.*\.elv' &transform={|s| re:replace '\.elv$' '' $s }
       }
     }
   ]
@@ -24,15 +24,15 @@ edit:completion:arg-completer[use] = (
 
 use epm
 
-epm-completer-one  = (comp:sequence [ $epm:list~ ])
-epm-completer-many = (comp:sequence [ $epm:list~ ...])
-edit:completion:arg-completer[epm:query]     = $epm-completer-one
-edit:completion:arg-completer[epm:metadata]  = $epm-completer-one
-edit:completion:arg-completer[epm:dest]      = $epm-completer-one
-edit:completion:arg-completer[epm:uninstall] = $epm-completer-many
-edit:completion:arg-completer[epm:upgrade]   = $epm-completer-many
+var epm-completer-one  = (comp:sequence [ $epm:list~ ])
+var epm-completer-many = (comp:sequence [ $epm:list~ ...])
+set edit:completion:arg-completer[epm:query]     = $epm-completer-one
+set edit:completion:arg-completer[epm:metadata]  = $epm-completer-one
+set edit:completion:arg-completer[epm:dest]      = $epm-completer-one
+set edit:completion:arg-completer[epm:uninstall] = $epm-completer-many
+set edit:completion:arg-completer[epm:upgrade]   = $epm-completer-many
 
-edit:completion:arg-completer[elvish] = (comp:sequence ^
+set edit:completion:arg-completer[elvish] = (comp:sequence ^
   &opts= { elvish -help | comp:extract-opts &fold } ^
-  [ [arg]{ comp:files $arg &regex='\.elv$' } ] ^
+  [ {|arg| comp:files $arg &regex='\.elv$' } ] ^
 )

--- a/builtins.org
+++ b/builtins.org
@@ -64,10 +64,10 @@ Included completions:
 Load the completion framework and other libraries.
 
 #+begin_src elvish
-use ./comp
-use re
-use path
-use str
+  use ./comp
+  use re
+  use path
+  use str
 #+end_src
 
 ** use
@@ -75,24 +75,24 @@ use str
 Completer for the =use= command, which includes all modules in =~/.elvish/lib/=, but also allows completing relative paths starting with =./= or =../=.
 
 #+begin_src elvish
-edit:completion:arg-completer[use] = (
-  comp:sequence [
-    [stem]{
-      if (not (str:has-prefix $stem '.')) {
-        put './' '../'
-        put ~/.elvish/lib/**[nomatch-ok].elv | each [m]{
-          if (not (path:is-dir $m)) {
-            re:replace ~/.elvish/lib/'(.*).elv' '$1' $m
+  set edit:completion:arg-completer[use] = (
+    comp:sequence [
+      {|stem|
+        if (not (str:has-prefix $stem '.')) {
+          put './' '../'
+          put ~/.elvish/lib/**[nomatch-ok].elv | each {|m|
+            if (not (path:is-dir $m)) {
+              re:replace ~/.elvish/lib/'(.*).elv' '$1' $m
+            }
           }
+        } else {
+          if (eq $stem ".") { set stem = "./" }
+          if (eq $stem "..") { set stem = "../" }
+          comp:files $stem &regex='.*\.elv' &transform={|s| re:replace '\.elv$' '' $s }
         }
-      } else {
-        if (eq $stem ".") { stem = "./" }
-        if (eq $stem "..") { stem = "../" }
-        comp:files $stem &regex='.*\.elv' &transform=[s]{ re:replace '\.elv$' '' $s }
       }
-    }
-  ]
-)
+    ]
+  )
 #+end_src
 
 ** epm
@@ -100,15 +100,15 @@ edit:completion:arg-completer[use] = (
 Completers for the =epm= commands.
 
 #+begin_src elvish
-use epm
+  use epm
 
-epm-completer-one  = (comp:sequence [ $epm:list~ ])
-epm-completer-many = (comp:sequence [ $epm:list~ ...])
-edit:completion:arg-completer[epm:query]     = $epm-completer-one
-edit:completion:arg-completer[epm:metadata]  = $epm-completer-one
-edit:completion:arg-completer[epm:dest]      = $epm-completer-one
-edit:completion:arg-completer[epm:uninstall] = $epm-completer-many
-edit:completion:arg-completer[epm:upgrade]   = $epm-completer-many
+  var epm-completer-one  = (comp:sequence [ $epm:list~ ])
+  var epm-completer-many = (comp:sequence [ $epm:list~ ...])
+  set edit:completion:arg-completer[epm:query]     = $epm-completer-one
+  set edit:completion:arg-completer[epm:metadata]  = $epm-completer-one
+  set edit:completion:arg-completer[epm:dest]      = $epm-completer-one
+  set edit:completion:arg-completer[epm:uninstall] = $epm-completer-many
+  set edit:completion:arg-completer[epm:upgrade]   = $epm-completer-many
 #+end_src
 
 ** elvish
@@ -116,8 +116,8 @@ edit:completion:arg-completer[epm:upgrade]   = $epm-completer-many
 Completer for the =elvish= command.
 
 #+begin_src elvish
-edit:completion:arg-completer[elvish] = (comp:sequence ^
-  &opts= { elvish -help | comp:extract-opts &fold } ^
-  [ [arg]{ comp:files $arg &regex='\.elv$' } ] ^
-)
+  set edit:completion:arg-completer[elvish] = (comp:sequence ^
+    &opts= { elvish -help | comp:extract-opts &fold } ^
+    [ {|arg| comp:files $arg &regex='\.elv$' } ] ^
+  )
 #+end_src

--- a/cd.elv
+++ b/cd.elv
@@ -1,5 +1,5 @@
 use ./comp
 
-edit:completion:arg-completer[cd] = (comp:sequence [ [stem]{
+set edit:completion:arg-completer[cd] = (comp:sequence [ {|stem|
       comp:files $stem &dirs-only
 }])

--- a/cd.org
+++ b/cd.org
@@ -11,9 +11,9 @@ Completes directory names for the =cd= command.
 :END:
 
 #+begin_src elvish
-use ./comp
+  use ./comp
 
-edit:completion:arg-completer[cd] = (comp:sequence [ [stem]{
-      comp:files $stem &dirs-only
-}])
+  set edit:completion:arg-completer[cd] = (comp:sequence [ {|stem|
+        comp:files $stem &dirs-only
+  }])
 #+end_src

--- a/comp.org
+++ b/comp.org
@@ -288,15 +288,15 @@ edit:completion:arg-completer[use] = (comp:sequence [
 We start by loading some basic modules we need.
 
 #+begin_src elvish
-use re
-use str
-use path
+  use re
+  use str
+  use path
 #+end_src
 
 The =$comp:debug= variable triggers printing debug messages to the terminal.
 
 #+begin_src elvish
-debug = $false
+  var debug = $false
 #+end_src
 
 ** Utility functions
@@ -306,11 +306,11 @@ debug = $false
 Internal function to print debug messages if the =$comp:debug= variable is set.
 
 #+begin_src elvish
-fn -debugmsg [@args &color=blue]{
-  if $debug {
-    echo (styled (echo ">>> " $@args) $color) >/dev/tty
+  fn -debugmsg {|@args &color=blue|
+    if $debug {
+      echo (styled (echo ">>> " $@args) $color) >/dev/tty
+    }
   }
-}
 #+end_src
 
 *** comp:decorate
@@ -318,19 +318,19 @@ fn -debugmsg [@args &color=blue]{
 =comp:decorate= maps its input through =edit:complex-candidate= with the given options. Can be passed the same options as [[https://elvish.io/ref/edit.html#argument-completer][edit:complex-candidate]] except for =&display=, which does not make sense when multiple inputs are provided. In addition, if =&suffix= is specified, it is used to set both =&display-suffix= and =&code-suffix=.
 
 #+begin_src elvish
-fn decorate [@input &code-suffix='' &display-suffix='' &suffix='' &style='']{
-  # &style is currently ignored because it is not supported by Elvish
-  if (== (count $input) 0) {
-    input = [(all)]
+  fn decorate {|@input &code-suffix='' &display-suffix='' &suffix='' &style=''|
+    # &style is currently ignored because it is not supported by Elvish
+    if (== (count $input) 0) {
+      set input = [(all)]
+    }
+    if (not-eq $suffix '') {
+      set display-suffix = $suffix
+      set code-suffix = $suffix
+    }
+    each {|k|
+      edit:complex-candidate &code-suffix=$code-suffix &display=$k$display-suffix $k
+    } $input
   }
-  if (not-eq $suffix '') {
-    display-suffix = $suffix
-    code-suffix = $suffix
-  }
-  each [k]{
-    edit:complex-candidate &code-suffix=$code-suffix &display=$k$display-suffix $k
-  } $input
-}
 #+end_src
 
 *** comp:empty
@@ -338,7 +338,7 @@ fn decorate [@input &code-suffix='' &display-suffix='' &suffix='' &style='']{
 =comp:empty= produces no completions. It can be used to mark an item in a sequence that should not produce any completions.
 
 #+begin_src elvish
-fn empty { nop }
+  fn empty { nop }
 #+end_src
 
 *** comp:files and comp:dirs
@@ -349,26 +349,26 @@ fn empty { nop }
 =comp:files= completes filenames, using any typed prefix as the stem. If the =&regex= option is specified, only files matching that pattern are completed. If =&dirs-only= is =$true=, only directories are returned. If =&transform= is given, it must be a one-argument lambda that is used to transform completions. It receives a string for each one of the available completions, and it must produce as output the transformed completion.
 
 #+begin_src elvish
-fn files [arg &regex='' &dirs-only=$false &transform=$nil]{
-  edit:complete-filename $arg | each [c]{
-    x = $c[stem]
-    if (or (path:is-dir $x) (and (not $dirs-only) (or (eq $regex '') (re:match $regex $x)))) {
-      if $transform {
-        edit:complex-candidate ($transform $x)
-      } else {
-        put $c
+  fn files {|arg &regex='' &dirs-only=$false &transform=$nil|
+    edit:complete-filename $arg | each {|c|
+      var x = $c[stem]
+      if (or (path:is-dir $x) (and (not $dirs-only) (or (eq $regex '') (re:match $regex $x)))) {
+        if $transform {
+          edit:complex-candidate ($transform $x)
+        } else {
+          put $c
+        }
       }
     }
   }
-}
 #+end_src
 
 =comp:dirs= is simply a convenience wrapper around =comp:files= which sets =&dirs-only= automatically.
 
 #+begin_src elvish
-fn dirs [arg &regex='' &transform=$nil]{
-  files $arg &regex=$regex &dirs-only=$true &transform=$transform
-}
+  fn dirs {|arg &regex='' &transform=$nil|
+    files $arg &regex=$regex &dirs-only=$true &transform=$transform
+  }
 #+end_src
 
 *** comp:extract-opts
@@ -380,66 +380,66 @@ If =&fold= is =$true=, then the input is preprocessed to join option description
 If the =&opt-completers= option is given, it must be a map from argument option descriptions as they appear in the help output (e.g. ENV, PATH, CHANNEL) to functions which will be used to produce their completions. By default the =comp:files= completer is used.
 
 #+begin_src elvish :noweb yes
-fn extract-opts [@cmd
-  <<opt-capture-regex>>
-  <<opt-capture-map>>
-  &fold=$false
-  &first-sentence=$false
-  &opt-completers=[&]
-]{
-  -line = ''
-  capture = $all~
-  if $fold {
-    capture = { each [l]{
-        if (re:match '^\s{8,}\w' $l) {
-          var folded = $-line$l
-          # -debugmsg "Folded line: "$folded
-          put $folded
-          -line = ''
-        } else {
-          # -debugmsg "Non-folded line: "$-line
-          put $-line
-          -line = $l
-        }
-      }
-    }
-  }
-  $capture | each [l]{
-    -debugmsg "Got line: "$l
-    re:find $regex $l
-  } | each [m]{
-    -debugmsg "Matches: "(to-string $m) &color=red
-    g = $m[groups]
-    opt = [&]
-    keys $regex-map | each [k]{
-      if (has-key $g $regex-map[$k]) {
-        field = (str:trim-space $g[$regex-map[$k]][text])
-        if (not-eq $field '') {
-          if (has-value [arg-optional arg-required] $k) {
-            opt[$k] = $true
-            opt[arg-desc] = $field
-            if (has-key $opt-completers $field) {
-              opt[arg-completer] = $opt-completers[$field]
-            } else {
-              opt[arg-completer] = $edit:complete-filename~
-            }
+  fn extract-opts {|@cmd
+    <<opt-capture-regex>>
+    <<opt-capture-map>>
+    &fold=$false
+    &first-sentence=$false
+    &opt-completers=[&]
+  |
+    var -line = ''
+    var capture = $all~
+    if $fold {
+      set capture = { each {|l|
+          if (re:match '^\s{8,}\w' $l) {
+            var folded = $-line$l
+            # -debugmsg "Folded line: "$folded
+            put $folded
+            set -line = ''
           } else {
-            opt[$k] = $field
+            # -debugmsg "Non-folded line: "$-line
+            put $-line
+            set -line = $l
           }
         }
       }
     }
-    if (or (has-key $opt short) (has-key $opt long)) {
-      if (has-key $opt desc) {
-        if $first-sentence {
-          opt[desc] = (re:replace '\. .*$|\.\s*$|\s*\(.*$' '' $opt[desc])
-        } 
-        opt[desc] = (re:replace '\s+' ' ' $opt[desc])
+    $capture | each {|l|
+      -debugmsg "Got line: "$l
+      re:find $regex $l
+    } | each {|m|
+      -debugmsg "Matches: "(to-string $m) &color=red
+      var g = $m[groups]
+      var opt = [&]
+      keys $regex-map | each {|k|
+        if (has-key $g $regex-map[$k]) {
+          var field = (str:trim-space $g[$regex-map[$k]][text])
+          if (not-eq $field '') {
+            if (has-value [arg-optional arg-required] $k) {
+              set opt[$k] = $true
+              set opt[arg-desc] = $field
+              if (has-key $opt-completers $field) {
+                set opt[arg-completer] = $opt-completers[$field]
+              } else {
+                set opt[arg-completer] = $edit:complete-filename~
+              }
+            } else {
+              set opt[$k] = $field
+            }
+          }
+        }
       }
-      put $opt
+      if (or (has-key $opt short) (has-key $opt long)) {
+        if (has-key $opt desc) {
+          if $first-sentence {
+            set opt[desc] = (re:replace '\. .*$|\.\s*$|\s*\(.*$' '' $opt[desc])
+          } 
+          set opt[desc] = (re:replace '\s+' ' ' $opt[desc])
+        }
+        put $opt
+      }
     }
   }
-}
 #+end_src
 
 *** comp:-handler-arity
@@ -447,14 +447,14 @@ fn extract-opts [@cmd
 Determine the arity of a function and return a string representation, for internal use.
 
 #+begin_src elvish
-fn -handler-arity [func]{
-  fnargs = [ (to-string (count $func[arg-names])) (== $func[rest-arg] -1)]
-  if     (eq $fnargs [ 0 $true ])  { put no-args
-  } elif (eq $fnargs [ 1 $true ])  { put one-arg
-  } elif (eq $fnargs [ 1 $false ]) { put rest-arg
-  } else {                           put other-args
+  fn -handler-arity {|func|
+    var fnargs = [ (to-string (count $func[arg-names])) (== $func[rest-arg] -1)]
+    if     (eq $fnargs [ 0 $true ])  { put no-args
+    } elif (eq $fnargs [ 1 $true ])  { put one-arg
+    } elif (eq $fnargs [ 1 $false ]) { put rest-arg
+    } else {                           put other-args
+    }
   }
-}
 #+end_src
 
 ** Completion functions
@@ -466,21 +466,21 @@ The backend completion functions =comp:-expand-item=, =comp:-expand-sequence= an
 =comp:-expand-item=  expands a "completion item" into its completion values. If it's a function, it gets executed with arguments corresponding to its arity; if it's a list, it's exploded to its elements.
 
 #+begin_src elvish
-fn -expand-item [def @cmd]{
-  arg = $cmd[-1]
-  what = (kind-of $def)
-  if (eq $what 'fn') {
-    [ &no-args=  { $def }
-      &one-arg=  { $def $arg }
-      &rest-arg= { $def $@cmd }
-      &other-args= { put '<expand-item-completion-fn-arity-error>' }
-    ][(-handler-arity $def)]
-  } elif (eq $what 'list') {
-    all $def
-  } else {
-    echo (styled "comp:-expand-item: invalid item of type "$what": "(to-string $def) red) >/dev/tty
+  fn -expand-item {|def @cmd|
+    var arg = $cmd[-1]
+    var what = (kind-of $def)
+    if (eq $what 'fn') {
+      [ &no-args=  { $def }
+        &one-arg=  { $def $arg }
+        &rest-arg= { $def $@cmd }
+        &other-args= { put '<expand-item-completion-fn-arity-error>' }
+      ][(-handler-arity $def)]
+    } elif (eq $what 'list') {
+      all $def
+    } else {
+      echo (styled "comp:-expand-item: invalid item of type "$what": "(to-string $def) red) >/dev/tty
+    }
   }
-}
 #+end_src
 
 *** comp:-expand-sequence
@@ -488,7 +488,7 @@ fn -expand-item [def @cmd]{
 =comp:-expand-sequence= receives an array of definition items and the current contents of the command line, and uses =edit:complete-getopt= to actually generate the completions. For this, we need to make sure the options and argument handler data structures are in accordance to what =edit:complete-getopt= expects.
 
 #+begin_src elvish
-fn -expand-sequence [seq @cmd &opts=[]]{
+  fn -expand-sequence {|seq @cmd &opts=[]|
 #+end_src
 
 We first preprocess the options. If =&opts= is provided, it has to be a completion item which expands to a list with one element per option. Elements that are maps are assumed to be in getopt format (with keys =short=, =long=, =desc=, =arg-required=, =arg-optional= and =arg-desc=) and used as-is (their structure is not checked). Elements which are strings are considered as long option names and converted to the appropriate data structure.
@@ -496,50 +496,50 @@ We first preprocess the options. If =&opts= is provided, it has to be a completi
 Because =edit:complete-getopt= supports option argument completion with key =completer=. So if option structure has an =arg-completer= key, then it is expanded as an completion item and offers as a completer.
 
 #+begin_src elvish
-final-opts = [(
-    -expand-item $opts $@cmd | each [opt]{
-      -debugmsg "In final-opts: opt before="(to-string $opt) &color=yellow
-      if (eq (kind-of $opt) map) {
-        if (has-key $opt arg-completer) {
-          -debugmsg &color=yellow "Assigning opt[completer] = [_]{ -expand-item "(to-string $opt[arg-completer]) $@cmd "}" 
-          opt[completer] = [_]{ -expand-item $opt[arg-completer] $@cmd }
+  var final-opts = [(
+      -expand-item $opts $@cmd | each {|opt|
+        -debugmsg "In final-opts: opt before="(to-string $opt) &color=yellow
+        if (eq (kind-of $opt) map) {
+          if (has-key $opt arg-completer) {
+            -debugmsg &color=yellow "Assigning opt[completer] = [_]{ -expand-item "(to-string $opt[arg-completer]) $@cmd "}" 
+            set opt[completer] = {|_| -expand-item $opt[arg-completer] $@cmd }
+          }
+          -debugmsg "In final-opts: opt after="(to-string $opt) &color=yellow
+          put $opt
+        } else {
+          put [&long= $opt]
         }
-        -debugmsg "In final-opts: opt after="(to-string $opt) &color=yellow
-        put $opt
-      } else {
-        put [&long= $opt]
       }
-    }
-)]
+  )]
 #+end_src
 
 We also preprocess the handlers. =edit:complete-getopt= expects each handler to receive only one argument (the current word in the command line), but =comp= allows handlers to receive no arguments, one argument (the current element of the command line) or multiple arguments (the whole command line), so we need to normalize them. Happily, Elvish's functional nature makes this easy by checking the arity of each handler and, if necessary, wrapping them in one-argument functions, but passing them the information they expect. We also wrap items which are arrays into corresponding functions. As a special case, the string ='...'= is also passed, as it is allowed by =edit:complete-getopt= to indicate that the last element needs to be repeated for future elements. Any other handlers are ignored.
 
 #+begin_src elvish
-final-handlers = [(
-    all $seq | each [f]{
-      if (eq (kind-of $f) 'fn') {
-        put [
-          &no-args=  [_]{ $f }
-          &one-arg=  $f
-          &rest-arg= [_]{ $f $@cmd }
-          &other-args= [_]{ put '<expand-sequence-completion-fn-arity-error>' }
-        ][(-handler-arity $f)]
-      } elif (eq (kind-of $f) 'list') {
-        put [_]{ all $f }
-      } elif (and (eq (kind-of $f) 'string') (eq $f '...')) {
-        put $f
+  var final-handlers = [(
+      all $seq | each {|f|
+        if (eq (kind-of $f) 'fn') {
+          put [
+            &no-args=  {|_| $f }
+            &one-arg=  $f
+            &rest-arg= {|_| $f $@cmd }
+            &other-args= {|_| put '<expand-sequence-completion-fn-arity-error>' }
+          ][(-handler-arity $f)]
+        } elif (eq (kind-of $f) 'list') {
+          put {|_| all $f }
+        } elif (and (eq (kind-of $f) 'string') (eq $f '...')) {
+          put $f
+        }
       }
-    }
-)]
+  )]
 #+end_src
 
 Finally, we call =edit:complete-getopt= with the corresponding data structures. It expects the current line /without/ the initial command, so we remove that as well.
 
 #+begin_src elvish
--debugmsg Calling: edit:complete-getopt (to-string $cmd[1..]) (to-string $final-opts) (to-string $final-handlers)
-edit:complete-getopt $cmd[1..] $final-opts $final-handlers
-}
+  -debugmsg Calling: edit:complete-getopt (to-string $cmd[1..]) (to-string $final-opts) (to-string $final-handlers)
+  edit:complete-getopt $cmd[1..] $final-opts $final-handlers
+  }
 #+end_src
 
 *** comp:-expand-subcommands
@@ -547,39 +547,39 @@ edit:complete-getopt $cmd[1..] $final-opts $final-handlers
 =comp:-expand-subcommands= receives a definition map and the current contents of the command line.
 
 #+begin_src elvish
-fn -expand-subcommands [def @cmd &opts=[]]{
+  fn -expand-subcommands {|def @cmd &opts=[]|
 #+end_src
 
 The algorithm for =comp:-expand-subcommands= is a bit counterintuitive, this is how it works:
 
 1. Scan the current command to see if a valid subcommand is found (i.e. an element which matches an existing key in =$def=).
    #+begin_src elvish
-subcommands = [(keys $def)]
-n = (count $cmd)
-kw = [(range 1 $n | each [i]{
-      if (has-value $subcommands $cmd[$i]) { put $cmd[$i] $i }
-})]
+     var subcommands = [(keys $def)]
+     var n = (count $cmd)
+     var kw = [(range 1 $n | each {|i|
+           if (has-value $subcommands $cmd[$i]) { put $cmd[$i] $i }
+     })]
    #+end_src
 
 2. If a subcommand is found, call its expansion function directly, and with the command line at that position. We check if the definition is a string, in which case it's expected to be the name of some other command whose definition we need to use (to implement command aliases) - we substitute the alias for its target command and call =-expand-subcommands= with the new values.
    #+begin_src elvish
-if (and (not-eq $kw []) (not-eq $kw[1] (- $n 1))) {
-  sc sc-pos = $kw[0 1]
-  if (eq (kind-of $def[$sc]) 'string') {
-    cmd[$sc-pos] = $def[$sc]
-    -expand-subcommands &opts=$opts $def $@cmd
-  } else {
-    $def[$sc] (all $cmd[{$sc-pos}..])
-  }
+     if (and (not-eq $kw []) (not-eq $kw[1] (- $n 1))) {
+       var sc sc-pos = $kw[0 1]
+       if (eq (kind-of $def[$sc]) 'string') {
+         set cmd[$sc-pos] = $def[$sc]
+         -expand-subcommands &opts=$opts $def $@cmd
+       } else {
+         $def[$sc] (all $cmd[{$sc-pos}..])
+       }
    #+end_src
 
 3. If no subcommand is found, generate a sequence definition which returns the subcommand names for the first position (including any provided options).
    #+begin_src elvish
-      } else {
-        top-def = [ { put $@subcommands } ]
-        -expand-sequence &opts=$opts $top-def $@cmd
-      }
-    }
+     } else {
+         var top-def = [ { put $@subcommands } ]
+         -expand-sequence &opts=$opts $top-def $@cmd
+       }
+     }
    #+end_src
 
 This seems backwards from what one (or at least I) initially expected - I attempted at first multiple variations to expand the subcommands/top-options first, and then only expand the subcommand options and definition from the "tail" handlers, but this doesn't work because of the way =edit:complete-getops= works, the top-level options would get expanded for subcommands as well. This way, we catch the more specific case first (subcommand definition) and only if there's no subcommand in the command line yet, we do the top-level expansion. All with simple and clear code (you wouldn't believe some of the variations I tried while trying to get this to work!).
@@ -591,52 +591,52 @@ The wrapper functions =comp:item=, =comp:sequence= and =comp:subcommands= are th
 *** comp:item
 
 #+begin_src elvish
-fn item [item &pre-hook=$nop~ &post-hook=$nop~]{
-  put [@cmd]{
-    $pre-hook $@cmd
-    result = [(-expand-item $item $@cmd)]
-    $post-hook $result $@cmd
-    put $@result
+  fn item {|item &pre-hook=$nop~ &post-hook=$nop~|
+    put {|@cmd|
+      $pre-hook $@cmd
+      var result = [(-expand-item $item $@cmd)]
+      $post-hook $result $@cmd
+      put $@result
+    }
   }
-}
 #+end_src
 
 *** comp:sequence
 
 #+begin_src elvish
-fn sequence [sequence &opts=[] &pre-hook=$nop~ &post-hook=$nop~]{
-  put [@cmd &inspect=$false]{
-    if $inspect {
-      echo "comp:sequence definition: "(to-string $sequence)
-      echo "opts: "(to-string $opts)
-    } else {
-      $pre-hook $@cmd
-      result = [(-expand-sequence &opts=$opts $sequence $@cmd)]
-      $post-hook $result $@cmd
-      put $@result
+  fn sequence {|sequence &opts=[] &pre-hook=$nop~ &post-hook=$nop~|
+    put {|@cmd &inspect=$false|
+      if $inspect {
+        echo "comp:sequence definition: "(to-string $sequence)
+        echo "opts: "(to-string $opts)
+      } else {
+        $pre-hook $@cmd
+        var result = [(-expand-sequence &opts=$opts $sequence $@cmd)]
+        $post-hook $result $@cmd
+        put $@result
+      }
     }
   }
-}
 #+end_src
 
 *** comp:subcommands
 
 #+begin_src elvish
-fn subcommands [def &opts=[] &pre-hook=$nop~ &post-hook=$nop~]{
-  put [@cmd &inspect=$false]{
-    if $inspect {
-      echo "Completer definition: "(to-string $def)
-      echo "opts: "(to-string $opts)
-    } else {
-      $pre-hook $@cmd
-      if (and (eq $opts []) (has-key $def -options)) {
-        opts = $def[-options]
+  fn subcommands {|def &opts=[] &pre-hook=$nop~ &post-hook=$nop~|
+    put {|@cmd &inspect=$false|
+      if $inspect {
+        echo "Completer definition: "(to-string $def)
+        echo "opts: "(to-string $opts)
+      } else {
+        $pre-hook $@cmd
+        if (and (eq $opts []) (has-key $def -options)) {
+          set opts = $def[-options]
+        }
+        del def[-options]
+        var result = [(-expand-subcommands &opts=$opts $def $@cmd)]
+        $post-hook $result $@cmd
+        put $@result
       }
-      del def[-options]
-      result = [(-expand-subcommands &opts=$opts $def $@cmd)]
-      $post-hook $result $@cmd
-      put $@result
     }
   }
-}
 #+end_src

--- a/dd.elv
+++ b/dd.elv
@@ -1,13 +1,13 @@
 use str
 
-fn -comma-sep-list [options arg]{
-  prefix = $arg[..(+ 1 (str:last-index $arg ','))]
+fn -comma-sep-list {|options arg|
+  var prefix = $arg[..(+ 1 (str:last-index $arg ','))]
   for option [(keys $options)] {
     edit:complex-candidate &display=$options[$option] $prefix$option
   }
 }
 
--convs = [
+var -convs = [
   &ascii=    "ascii      (from EBCDIC to ASCII)"
   &ebcdic=   "ebcdic     (from ASCII to EBCDIC)"
   &ibm=      "ibm        (from ASCII to alternate EBCDIC)"
@@ -26,7 +26,7 @@ fn -comma-sep-list [options arg]{
   &fsync=    "fsync      (likewise, but also write metadata)"
 ]
 
--flags = [
+var -flags = [
   &append=     "append       (append mode (makes sense only for output; conv=notrunc suggested))"
   &direct=     "direct       (use direct I/O for data)"
   &directory=  "directory    (fail unless a directory)"
@@ -43,31 +43,31 @@ fn -comma-sep-list [options arg]{
   &seek_bytes= "seek_bytes   (treat 'seek=N' as a byte count (oflag only))"
 ]
 
--operands = [
+var -operands = [
   &bs=    [&desc="read and write up to BYTES bytes at a time (default: 512); overrides ibs and obs"]
   &cbs=   [&desc="convert BYTES bytes at a time"]
   &conv=  [&desc="convert the file as per the comma separated symbol list"
-           &comp=[arg]{ -comma-sep-list $-convs $arg }]
+           &comp={|arg| -comma-sep-list $-convs $arg }]
   &count= [&desc="copy only N input blocks"]
   &ibs=   [&desc="read up to BYTES bytes at a time (default: 512)"]
   &if=    [&desc="read from FILE instead of stdin"
            &comp=$edit:complete-filename~]
   &iflag= [&desc="read as per the comma separated symbol list"
-           &comp=[arg]{ -comma-sep-list $-flags $arg }]
+           &comp={|arg| -comma-sep-list $-flags $arg }]
   &obs=   [&desc="write BYTES bytes at a time (default: 512)"]
   &of=    [&desc="write to FILE instead of stdout"
            &comp=$edit:complete-filename~]
   &oflag= [&desc="write as per the comma separated symbol list"
-           &comp=[arg]{ -comma-sep-list $-flags $arg }]
+           &comp={|arg| -comma-sep-list $-flags $arg }]
   &seek=  [&desc="skip N obs-sized blocks at start of output"]
   &skip=  [&desc="skip N ibs-sized blocks at start of input"]
   &status=[&desc="The LEVEL of information to print to stderr"
-           &comp=[arg]{ all [none noxfer progress] }]
+           &comp={|arg| all [none noxfer progress] }]
 ]
 
-fn -completer [@cmd]{
-  last-arg = $cmd[-1]
-  op-length = (str:index $last-arg '=')
+fn -completer {|@cmd|
+  var last-arg = $cmd[-1]
+  var op-length = (str:index $last-arg '=')
 
 if (== -1 $op-length) {
   for op [(keys $-operands)] {
@@ -78,11 +78,11 @@ if (== -1 $op-length) {
   edit:complex-candidate &display="--version  (output version information and exit)" '--version'
 
 } else {
-  op = $last-arg[..$op-length]
-  arg = $last-arg[(+ 1 $op-length)..]
+  var op = $last-arg[..$op-length]
+  var arg = $last-arg[(+ 1 $op-length)..]
 
   if (has-key $-operands[$op] comp) {
-    $-operands[$op][comp] $arg | each [candidate]{
+    $-operands[$op][comp] $arg | each {|candidate|
 
 if (eq (kind-of $candidate) map) {
           put (edit:complex-candidate $op'='$candidate[stem] &display=$candidate[display])
@@ -94,4 +94,4 @@ if (eq (kind-of $candidate) map) {
   }
 }
 
-edit:completion:arg-completer[dd] = $-completer~
+set edit:completion:arg-completer[dd] = $-completer~

--- a/dd.org
+++ b/dd.org
@@ -12,88 +12,88 @@ Completions for =dd=, including operands, conversions, and flags.
 Conversions and flags are both specified as comma-separated lists, so let's have a single function for completing those, given a map of the options and their descriptions, and the argument typed so far (e.g. =foo,bar,b=). We simply take the already-typed options (before the last comma) and outputting each possible option with them tacked on to the start.
 
 #+begin_src elvish
-use str
+  use str
 
-fn -comma-sep-list [options arg]{
-  prefix = $arg[..(+ 1 (str:last-index $arg ','))]
-  for option [(keys $options)] {
-    edit:complex-candidate &display=$options[$option] $prefix$option
+  fn -comma-sep-list {|options arg|
+    var prefix = $arg[..(+ 1 (str:last-index $arg ','))]
+    for option [(keys $options)] {
+      edit:complex-candidate &display=$options[$option] $prefix$option
+    }
   }
-}
 #+end_src
 
 Now we define all the possible conversions and flags, as maps to pass to =-comma-sep-list=.
 
 #+begin_src elvish
--convs = [
-  &ascii=    "ascii      (from EBCDIC to ASCII)"
-  &ebcdic=   "ebcdic     (from ASCII to EBCDIC)"
-  &ibm=      "ibm        (from ASCII to alternate EBCDIC)"
-  &block=    "block      (pad newline-terminated records with spaces to cbs-size)"
-  &unblock=  "unblock    (replace trailing spaces in cbs-size records with newline)"
-  &lcase=    "lcase      (change upper case to lower case)"
-  &ucase=    "ucase      (change lower case to upper case)"
-  &sparse=   "sparse     (try to seek rather than write all-NUL output blocks)"
-  &swab=     "swab       (swap every pair of input bytes)"
-  &sync=     "sync       (pad every input block with NULs to ibs-size; when used with block or unblock, pad with spaces rather than NULs)"
-  &excl=     "excl       (fail if the output file already exists)"
-  &nocreat=  "nocreat    (do not create the output file)"
-  &notrunc=  "notrunc    (do not truncate the output file)"
-  &noerror=  "noerror    (continue after read errors)"
-  &fdatasync="fdatasync  (physically write output file data before finishing)"
-  &fsync=    "fsync      (likewise, but also write metadata)"
-]
+  var -convs = [
+    &ascii=    "ascii      (from EBCDIC to ASCII)"
+    &ebcdic=   "ebcdic     (from ASCII to EBCDIC)"
+    &ibm=      "ibm        (from ASCII to alternate EBCDIC)"
+    &block=    "block      (pad newline-terminated records with spaces to cbs-size)"
+    &unblock=  "unblock    (replace trailing spaces in cbs-size records with newline)"
+    &lcase=    "lcase      (change upper case to lower case)"
+    &ucase=    "ucase      (change lower case to upper case)"
+    &sparse=   "sparse     (try to seek rather than write all-NUL output blocks)"
+    &swab=     "swab       (swap every pair of input bytes)"
+    &sync=     "sync       (pad every input block with NULs to ibs-size; when used with block or unblock, pad with spaces rather than NULs)"
+    &excl=     "excl       (fail if the output file already exists)"
+    &nocreat=  "nocreat    (do not create the output file)"
+    &notrunc=  "notrunc    (do not truncate the output file)"
+    &noerror=  "noerror    (continue after read errors)"
+    &fdatasync="fdatasync  (physically write output file data before finishing)"
+    &fsync=    "fsync      (likewise, but also write metadata)"
+  ]
 
--flags = [
-  &append=     "append       (append mode (makes sense only for output; conv=notrunc suggested))"
-  &direct=     "direct       (use direct I/O for data)"
-  &directory=  "directory    (fail unless a directory)"
-  &dsync=      "dsync        (use synchronized I/O for data)"
-  &sync=       "sync         (likewise, but also for metadata)"
-  &fullblock=  "fullblock    (accumulate full blocks of input (iflag only))"
-  &nonblock=   "nonblock     (use non-blocking I/O)"
-  &noatime=    "noatime      (do not update access time)"
-  &nocache=    "nocache      (Request to drop cache.  See also oflag=sync)"
-  &noctty=     "noctty       (do not assign controlling terminal from file)"
-  &nofollow=   "nofollow     (do not follow symlinks)"
-  &count_bytes="count_bytes  (treat 'count=N' as a byte count (iflag only))"
-  &skip_bytes= "skip_bytes   (treat 'skip=N' as a byte count (iflag only))"
-  &seek_bytes= "seek_bytes   (treat 'seek=N' as a byte count (oflag only))"
-]
+  var -flags = [
+    &append=     "append       (append mode (makes sense only for output; conv=notrunc suggested))"
+    &direct=     "direct       (use direct I/O for data)"
+    &directory=  "directory    (fail unless a directory)"
+    &dsync=      "dsync        (use synchronized I/O for data)"
+    &sync=       "sync         (likewise, but also for metadata)"
+    &fullblock=  "fullblock    (accumulate full blocks of input (iflag only))"
+    &nonblock=   "nonblock     (use non-blocking I/O)"
+    &noatime=    "noatime      (do not update access time)"
+    &nocache=    "nocache      (Request to drop cache.  See also oflag=sync)"
+    &noctty=     "noctty       (do not assign controlling terminal from file)"
+    &nofollow=   "nofollow     (do not follow symlinks)"
+    &count_bytes="count_bytes  (treat 'count=N' as a byte count (iflag only))"
+    &skip_bytes= "skip_bytes   (treat 'skip=N' as a byte count (iflag only))"
+    &seek_bytes= "seek_bytes   (treat 'seek=N' as a byte count (oflag only))"
+  ]
 #+end_src
 
 Now we can define all the operands, with their descriptions and completion functions. Completion functions will be passed only the part of the argument after the ~=~, allowing us to reuse things like =edit:complete-filename~=.
 
 #+begin_src elvish
--operands = [
-  &bs=    [&desc="read and write up to BYTES bytes at a time (default: 512); overrides ibs and obs"]
-  &cbs=   [&desc="convert BYTES bytes at a time"]
-  &conv=  [&desc="convert the file as per the comma separated symbol list"
-           &comp=[arg]{ -comma-sep-list $-convs $arg }]
-  &count= [&desc="copy only N input blocks"]
-  &ibs=   [&desc="read up to BYTES bytes at a time (default: 512)"]
-  &if=    [&desc="read from FILE instead of stdin"
-           &comp=$edit:complete-filename~]
-  &iflag= [&desc="read as per the comma separated symbol list"
-           &comp=[arg]{ -comma-sep-list $-flags $arg }]
-  &obs=   [&desc="write BYTES bytes at a time (default: 512)"]
-  &of=    [&desc="write to FILE instead of stdout"
-           &comp=$edit:complete-filename~]
-  &oflag= [&desc="write as per the comma separated symbol list"
-           &comp=[arg]{ -comma-sep-list $-flags $arg }]
-  &seek=  [&desc="skip N obs-sized blocks at start of output"]
-  &skip=  [&desc="skip N ibs-sized blocks at start of input"]
-  &status=[&desc="The LEVEL of information to print to stderr"
-           &comp=[arg]{ all [none noxfer progress] }]
-]
+  var -operands = [
+    &bs=    [&desc="read and write up to BYTES bytes at a time (default: 512); overrides ibs and obs"]
+    &cbs=   [&desc="convert BYTES bytes at a time"]
+    &conv=  [&desc="convert the file as per the comma separated symbol list"
+             &comp={|arg| -comma-sep-list $-convs $arg }]
+    &count= [&desc="copy only N input blocks"]
+    &ibs=   [&desc="read up to BYTES bytes at a time (default: 512)"]
+    &if=    [&desc="read from FILE instead of stdin"
+             &comp=$edit:complete-filename~]
+    &iflag= [&desc="read as per the comma separated symbol list"
+             &comp={|arg| -comma-sep-list $-flags $arg }]
+    &obs=   [&desc="write BYTES bytes at a time (default: 512)"]
+    &of=    [&desc="write to FILE instead of stdout"
+             &comp=$edit:complete-filename~]
+    &oflag= [&desc="write as per the comma separated symbol list"
+             &comp={|arg| -comma-sep-list $-flags $arg }]
+    &seek=  [&desc="skip N obs-sized blocks at start of output"]
+    &skip=  [&desc="skip N ibs-sized blocks at start of input"]
+    &status=[&desc="The LEVEL of information to print to stderr"
+             &comp={|arg| all [none noxfer progress] }]
+  ]
 #+end_src
 
 The main completion function is only concerned with the last argument. First we need to know which part of the argument is the operand (before the ~=~).
 
 #+begin_src elvish
-fn -completer [@cmd]{
-  last-arg = $cmd[-1]
-  op-length = (str:index $last-arg '=')
+  fn -completer {|@cmd|
+    var last-arg = $cmd[-1]
+    var op-length = (str:index $last-arg '=')
 #+end_src
 
 If there isn't an equals, we offer the operands (and =--help= and =--version=, the only "normal-looking" options) as completions.
@@ -112,25 +112,25 @@ Otherwise, we lop off the operand and its ~=~, so that we can use nice simple co
 
 #+begin_src elvish
   } else {
-    op = $last-arg[..$op-length]
-    arg = $last-arg[(+ 1 $op-length)..]
+    var op = $last-arg[..$op-length]
+    var arg = $last-arg[(+ 1 $op-length)..]
 
     if (has-key $-operands[$op] comp) {
-      $-operands[$op][comp] $arg | each [candidate]{
+      $-operands[$op][comp] $arg | each {|candidate|
 #+end_src
 
 Since some of the completion functions use =edit:complex-candidate=, we have to remake them with the operand added back on.
 
 #+begin_src elvish
-        if (eq (kind-of $candidate) map) {
-          put (edit:complex-candidate $op'='$candidate[stem] &display=$candidate[display])
-        } else {
-          put $op'='$candidate
+  if (eq (kind-of $candidate) map) {
+            put (edit:complex-candidate $op'='$candidate[stem] &display=$candidate[display])
+          } else {
+            put $op'='$candidate
+          }
         }
       }
     }
   }
-}
 
-edit:completion:arg-completer[dd] = $-completer~
+  set edit:completion:arg-completer[dd] = $-completer~
 #+end_src

--- a/evemu.elv
+++ b/evemu.elv
@@ -1,25 +1,25 @@
 use ./comp
 use str
 
--complete-dev = {
-  evdev-dir = '/dev/input/'
-  ls $evdev-dir | each [item]{
+var -complete-dev = {
+  var evdev-dir = '/dev/input/'
+  ls $evdev-dir | each {|item|
     if (str:has-prefix $item 'event') {
-      path = $evdev-dir$item
-      name = (cat /sys/class/input/$item/device/name)
+      var path = $evdev-dir$item
+      var name = (cat /sys/class/input/$item/device/name)
       edit:complex-candidate &display=$path" ("$name")" $path
     }
   }
 }
 
-ev-code-header = /usr/include/linux/input-event-codes.h
+var ev-code-header = /usr/include/linux/input-event-codes.h
 
-fn -defs-with-prefix [prefix]{
+fn -defs-with-prefix {|prefix|
   grep "#define "$prefix"_" $ev-code-header |
-      eawk [line @fields]{ put $fields[1] }
+      eawk {|line @fields| put $fields[1] }
 }
 
-fn -ev-codes-for-type [type]{
+fn -ev-codes-for-type {|type|
   if (eq $type 'EV_KEY') {
     -defs-with-prefix 'KEY'
     -defs-with-prefix 'BTN'
@@ -28,49 +28,49 @@ fn -ev-codes-for-type [type]{
   }
 }
 
--evtest-opts = [
+var -evtest-opts = [
   [&long="grab"  &desc="grab the device for exclusive access"]
   [&long="query" &desc="query a specific single-bit event code"]
 ]
 
--complete-evtest-type = [@cmd]{
+var -complete-evtest-type = {|@cmd|
   if (eq $cmd[1] '--query') {
     all [EV_KEY EV_SW EV_SND EV_LED]
   }
 }
 
--complete-evtest-code = [@cmd]{
+var -complete-evtest-code = {|@cmd|
   if (eq $cmd[1] '--query') {
     -ev-codes-for-type $cmd[3]
   }
 }
 
-edit:completion:arg-completer[evtest] = (
+set edit:completion:arg-completer[evtest] = (
     comp:sequence &opts=$-evtest-opts [$-complete-dev $-complete-evtest-type $-complete-evtest-code])
 
--autorestart-opt = [
+var -autorestart-opt = [
   &long="autorestart"
   &desc="Terminate the current recording after <s> seconds of inactivity and restart a new recording"
   &arg-required=$true
 ]
 
--record-and-describe-comp = (comp:sequence &opts=[$-autorestart-opt] [$-complete-dev $comp:files~])
-edit:completion:arg-completer[evemu-describe] = $-record-and-describe-comp
-edit:completion:arg-completer[evemu-record] = $-record-and-describe-comp
+var -record-and-describe-comp = (comp:sequence &opts=[$-autorestart-opt] [$-complete-dev $comp:files~])
+set edit:completion:arg-completer[evemu-describe] = $-record-and-describe-comp
+set edit:completion:arg-completer[evemu-record] = $-record-and-describe-comp
 
-edit:completion:arg-completer[evemu-device] = $edit:complete-filename~
+set edit:completion:arg-completer[evemu-device] = $edit:complete-filename~
 
-edit:completion:arg-completer[evemu-play] = (comp:sequence [[arg]{
+set edit:completion:arg-completer[evemu-play] = (comp:sequence [{|arg|
   $-complete-dev
   comp:files $arg
 }])
 
--all-ev-codes = {
-  prefix-pattern = (-defs-with-prefix 'EV' | each [s]{ str:trim-prefix $s 'EV_' } | str:join '\|')
+var -all-ev-codes = {
+  var prefix-pattern = (-defs-with-prefix 'EV' | each {|s| str:trim-prefix $s 'EV_' } | str:join '\|')
   -defs-with-prefix '\('$prefix-pattern'\|BTN\)'
 }
 
--event-opts = [
+var -event-opts = [
   [&long="sync" &desc="generate an EV_SYN event after the event"]
   [&long="type"
    &desc="the type of event to generate"
@@ -85,4 +85,4 @@ edit:completion:arg-completer[evemu-play] = (comp:sequence [[arg]{
    &arg-required=$true]
 ]
 
-edit:completion:arg-completer[evemu-event] = (comp:sequence &opts=$-event-opts [$-complete-dev])
+set edit:completion:arg-completer[evemu-event] = (comp:sequence &opts=$-event-opts [$-complete-dev])

--- a/evemu.org
+++ b/evemu.org
@@ -14,43 +14,43 @@ Completions for [[https://gitlab.freedesktop.org/libevdev/evtest][=evtest=]] and
 All of these commands operate on evdev nodes, contained in =/dev/input/=. Each represents an input device (or part of one), with a name. We can retrieve that name from sysfs and show it next to the completion.
 
 #+begin_src elvish
-use ./comp
-use str
+  use ./comp
+  use str
 
--complete-dev = {
-  evdev-dir = '/dev/input/'
-  ls $evdev-dir | each [item]{
-    if (str:has-prefix $item 'event') {
-      path = $evdev-dir$item
-      name = (cat /sys/class/input/$item/device/name)
-      edit:complex-candidate &display=$path" ("$name")" $path
+  var -complete-dev = {
+    var evdev-dir = '/dev/input/'
+    ls $evdev-dir | each {|item|
+      if (str:has-prefix $item 'event') {
+        var path = $evdev-dir$item
+        var name = (cat /sys/class/input/$item/device/name)
+        edit:complex-candidate &display=$path" ("$name")" $path
+      }
     }
   }
-}
 #+end_src
 
 Some commands take axis or key constants defined in the Kernel's =input-event-codes.h=, each prefixed with a type (e.g. =KEY_A=, =BTN_LEFT=, or =REL_X=). We can list them with some simple matching against the header file.
 
 #+begin_src elvish
-ev-code-header = /usr/include/linux/input-event-codes.h
+  var ev-code-header = /usr/include/linux/input-event-codes.h
 
-fn -defs-with-prefix [prefix]{
-  grep "#define "$prefix"_" $ev-code-header |
-      eawk [line @fields]{ put $fields[1] }
-}
+  fn -defs-with-prefix {|prefix|
+    grep "#define "$prefix"_" $ev-code-header |
+        eawk {|line @fields| put $fields[1] }
+  }
 #+end_src
 
 Next we'll need a method to list all the constants corresponding to a particular event type, the name of which is prefixed by =EV_=. (The =KEY= type also includes the =BTN= constants.)
 
 #+begin_src elvish
-fn -ev-codes-for-type [type]{
-  if (eq $type 'EV_KEY') {
-    -defs-with-prefix 'KEY'
-    -defs-with-prefix 'BTN'
-  } else {
-    -defs-with-prefix (str:trim-prefix $type 'EV_')
+  fn -ev-codes-for-type {|type|
+    if (eq $type 'EV_KEY') {
+      -defs-with-prefix 'KEY'
+      -defs-with-prefix 'BTN'
+    } else {
+      -defs-with-prefix (str:trim-prefix $type 'EV_')
+    }
   }
-}
 #+end_src
 
 ** =evtest=
@@ -58,29 +58,29 @@ fn -ev-codes-for-type [type]{
 =evtest= only has two options.
 
 #+begin_src elvish
--evtest-opts = [
-  [&long="grab"  &desc="grab the device for exclusive access"]
-  [&long="query" &desc="query a specific single-bit event code"]
-]
+  var -evtest-opts = [
+    [&long="grab"  &desc="grab the device for exclusive access"]
+    [&long="query" &desc="query a specific single-bit event code"]
+  ]
 #+end_src
 
 ...but =--query= is a little tricky, as it takes two arguments: an event type (one with binary states), and a code of that type. We have to use completer functions that look at the other arguments by index.
 
 #+begin_src elvish
--complete-evtest-type = [@cmd]{
-  if (eq $cmd[1] '--query') {
-    all [EV_KEY EV_SW EV_SND EV_LED]
+  var -complete-evtest-type = {|@cmd|
+    if (eq $cmd[1] '--query') {
+      all [EV_KEY EV_SW EV_SND EV_LED]
+    }
   }
-}
 
--complete-evtest-code = [@cmd]{
-  if (eq $cmd[1] '--query') {
-    -ev-codes-for-type $cmd[3]
+  var -complete-evtest-code = {|@cmd|
+    if (eq $cmd[1] '--query') {
+      -ev-codes-for-type $cmd[3]
+    }
   }
-}
 
-edit:completion:arg-completer[evtest] = (
-    comp:sequence &opts=$-evtest-opts [$-complete-dev $-complete-evtest-type $-complete-evtest-code])
+  set edit:completion:arg-completer[evtest] = (
+      comp:sequence &opts=$-evtest-opts [$-complete-dev $-complete-evtest-type $-complete-evtest-code])
 #+end_src
 
 ** =evemu-record= and =evemu-describe=
@@ -88,21 +88,21 @@ edit:completion:arg-completer[evtest] = (
 These commands both take the same simple set of arguments.
 
 #+begin_src elvish
--autorestart-opt = [
-  &long="autorestart"
-  &desc="Terminate the current recording after <s> seconds of inactivity and restart a new recording"
-  &arg-required=$true
-]
+  var -autorestart-opt = [
+    &long="autorestart"
+    &desc="Terminate the current recording after <s> seconds of inactivity and restart a new recording"
+    &arg-required=$true
+  ]
 
--record-and-describe-comp = (comp:sequence &opts=[$-autorestart-opt] [$-complete-dev $comp:files~])
-edit:completion:arg-completer[evemu-describe] = $-record-and-describe-comp
-edit:completion:arg-completer[evemu-record] = $-record-and-describe-comp
+  var -record-and-describe-comp = (comp:sequence &opts=[$-autorestart-opt] [$-complete-dev $comp:files~])
+  set edit:completion:arg-completer[evemu-describe] = $-record-and-describe-comp
+  set edit:completion:arg-completer[evemu-record] = $-record-and-describe-comp
 #+end_src
 
 ** =evemu-device=
 
 #+begin_src elvish
-edit:completion:arg-completer[evemu-device] = $edit:complete-filename~
+  set edit:completion:arg-completer[evemu-device] = $edit:complete-filename~
 #+end_src
 
 ** =evemu-play=
@@ -110,10 +110,10 @@ edit:completion:arg-completer[evemu-device] = $edit:complete-filename~
 This command takes either an evdev device or a recording file.
 
 #+begin_src elvish
-edit:completion:arg-completer[evemu-play] = (comp:sequence [[arg]{
-  $-complete-dev
-  comp:files $arg
-}])
+  set edit:completion:arg-completer[evemu-play] = (comp:sequence [{|arg|
+    $-complete-dev
+    comp:files $arg
+  }])
 #+end_src
 
 ** =evemu-event=
@@ -121,25 +121,25 @@ edit:completion:arg-completer[evemu-play] = (comp:sequence [[arg]{
 This command, for generating single events, has an argument that could take any event code, so we put all the possible event types (as well as =BTN_=, an additional prefix for the =EV_KEY= type) into a regex with which to retrieve the constants.
 
 #+begin_src elvish
--all-ev-codes = {
-  prefix-pattern = (-defs-with-prefix 'EV' | each [s]{ str:trim-prefix $s 'EV_' } | str:join '\|')
-  -defs-with-prefix '\('$prefix-pattern'\|BTN\)'
-}
+  var -all-ev-codes = {
+    var prefix-pattern = (-defs-with-prefix 'EV' | each {|s| str:trim-prefix $s 'EV_' } | str:join '\|')
+    -defs-with-prefix '\('$prefix-pattern'\|BTN\)'
+  }
 
--event-opts = [
-  [&long="sync" &desc="generate an EV_SYN event after the event"]
-  [&long="type"
-   &desc="the type of event to generate"
-   &arg-required=$true
-   &arg-completer={ -defs-with-prefix 'EV' }]
-  [&long="code"
-   &desc="the event code"
-   &arg-required=$true
-   &arg-completer=$-all-ev-codes]
-  [&long="value"
-   &desc="the event value"
-   &arg-required=$true]
-]
+  var -event-opts = [
+    [&long="sync" &desc="generate an EV_SYN event after the event"]
+    [&long="type"
+     &desc="the type of event to generate"
+     &arg-required=$true
+     &arg-completer={ -defs-with-prefix 'EV' }]
+    [&long="code"
+     &desc="the event code"
+     &arg-required=$true
+     &arg-completer=$-all-ev-codes]
+    [&long="value"
+     &desc="the event value"
+     &arg-required=$true]
+  ]
 
-edit:completion:arg-completer[evemu-event] = (comp:sequence &opts=$-event-opts [$-complete-dev])
+  set edit:completion:arg-completer[evemu-event] = (comp:sequence &opts=$-event-opts [$-complete-dev])
 #+end_src

--- a/git.org
+++ b/git.org
@@ -38,18 +38,18 @@ Now you can type =git<space>=, press ~Tab~ and see the corresponding completions
 Several components are colorized, you can configure the styles by setting these variables (default values shown):
 
 #+begin_src elvish :noweb-ref git-completion-styles
-modified-style  = yellow
-untracked-style = red
-tracked-style   = ''
-branch-style    = blue
-remote-style    = cyan
-unmerged-style  = magenta
+var modified-style  = yellow
+var untracked-style = red
+var tracked-style   = ''
+var branch-style    = blue
+var remote-style    = cyan
+var unmerged-style  = magenta
 #+end_src
 
 You can change which command is used instead of =git= by assigning it to =$git:git-command=. The command assigned needs to understand at least the same commands and options as =git=. One example of such command is [[https://hub.github.com/][hub]]. You can also assign functions (for example, a wrapper function around =git=).
 
 #+begin_src elvish :noweb-ref git-command
-git-command = git
+var git-command = git
 #+end_src
 
 * Implementation
@@ -63,29 +63,29 @@ git-command = git
 We first load a number of libraries, including =comp=, the Elvish completion framework.
 
 #+begin_src elvish
-use ./comp
-use re
-use str
-use github.com/muesli/elvish-libs/git
-use github.com/zzamboni/elvish-modules/util
+  use ./comp
+  use re
+  use str
+  use github.com/muesli/elvish-libs/git
+  use github.com/zzamboni/elvish-modules/util
 #+end_src
 
 This is where the big completion-definition map will get progressively built.
 
 #+begin_src elvish
-completions = [&]
+  var completions = [&]
 #+end_src
 
 We store the output of =git:status= in a global variable to make it easier to access by the different completion functions.
 
 #+begin_src elvish
-status = [&]
+  var status = [&]
 #+end_src
 
 Here we will store the completer function (for easier access and for testing).
 
 #+begin_src elvish
-git-arg-completer = { }
+  var git-arg-completer = { }
 #+end_src
 
 ** Configuration variables
@@ -99,7 +99,12 @@ The =git-command= variable contains the command or function to run instead of =g
 The =$*-style= variables contains the style (as per =styled=) to use for different completion components the completion menu. Set to =''= (an empty string) to show in the normal style.
 
 #+begin_src elvish :noweb yes
-<<git-completion-styles>>
+  var modified-style  = yellow
+  var untracked-style = red
+  var tracked-style   = ''
+  var branch-style    = blue
+  var remote-style    = cyan
+  var unmerged-style  = magenta
 #+end_src
 
 ** Utility functions
@@ -109,55 +114,55 @@ The =-run-git= function executes a git-like command, with the given arguments.  
 (please note: =$git-command= is only used for command executed from within this module, not from the =muesli/git= module which is used for some pieces of information, so the integration is not yet perfect. But for most commands it should work - for example if you use =hub= instead of =git=.
 
 #+begin_src elvish
-fn -run-git [@rest]{
-  gitcmds = [$git-command]
-  if (eq (kind-of $git-command) string) {
-    gitcmds = [(re:split " " $git-command)]
+  fn -run-git {|@rest|
+    var gitcmds = [$git-command]
+    if (eq (kind-of $git-command) string) {
+      set gitcmds = [(re:split " " $git-command)]
+    }
+    var cmd = $gitcmds[0]
+    if (eq (kind-of $cmd) string) {
+      set cmd = (external $cmd)
+    }
+    $cmd (all $gitcmds[1..]) $@rest
   }
-  cmd = $gitcmds[0]
-  if (eq (kind-of $cmd) string) {
-    cmd = (external $cmd)
-  }
-  $cmd (all $gitcmds[1..]) $@rest
-}
 #+end_src
 
 The =-git-opts= function receives an optional git command, runs =git [command] -h= and parses the output to extract the command line options. The parsing is done with =comp:extract-opts=, but we pre-process the output to join options whose descriptions appear in the next line.
 
 #+begin_src elvish
-fn -git-opts [@cmd]{
-  _ = ?(-run-git $@cmd -h 2>&1) | drop 1 | if (eq $cmd []) {
-    comp:extract-opts &fold=$true &regex='--(\w[\w-]*)' &regex-map=[&long=1]
-  } else {
-    comp:extract-opts &fold=$true
+  fn -git-opts {|@cmd|
+    set _ = ?(-run-git $@cmd -h 2>&1) | drop 1 | if (eq $cmd []) {
+      comp:extract-opts &fold=$true &regex='--(\w[\w-]*)' &regex-map=[&long=1]
+    } else {
+      comp:extract-opts &fold=$true
+    }
   }
-}
 #+end_src
 
 We define the functions that return different possible values used in the completions. Some of these functions assume that =$status= contains already the output from =git:status=, which gets executed as the pre-hook of the git completer function below.
 
 #+begin_src elvish
-fn MODIFIED      { all $status[local-modified] | comp:decorate &style=$modified-style }
-fn UNTRACKED     { all $status[untracked] | comp:decorate &style=$untracked-style }
-fn UNMERGED      { all $status[unmerged] | comp:decorate &style=$unmerged-style }
-fn MOD-UNTRACKED { MODIFIED; UNTRACKED }
-fn TRACKED       { _ = ?(-run-git ls-files 2>&-) | comp:decorate &style=$tracked-style }
-fn BRANCHES      [&all=$false &branch=$true]{
-  -allarg = []
-  -branch = ''
-  if $all { -allarg = ['--all'] }
-  if $branch { -branch = ' (branch)' }
-  _ = ?(-run-git branch --list (all $-allarg) --format '%(refname:short)' 2>&- |
-  comp:decorate &display-suffix=$-branch &style=$branch-style)
-}
-fn REMOTE-BRANCHES {
-  _ = ?(-run-git branch --list --remote --format '%(refname:short)' 2>&- |
-    grep -v HEAD |
-    each [branch]{ re:replace 'origin/' '' $branch } |
-  comp:decorate &display-suffix=' (remote branch)' &style=$branch-style)
-}
-fn REMOTES       { _ = ?(-run-git remote 2>&- | comp:decorate &display-suffix=' (remote)' &style=$remote-style ) }
-fn STASHES       { _ = ?(-run-git stash list 2>&- | each [l]{ put [(re:split : $l)][0] } ) }
+  fn MODIFIED      { all $status[local-modified] | comp:decorate &style=$modified-style }
+  fn UNTRACKED     { all $status[untracked] | comp:decorate &style=$untracked-style }
+  fn UNMERGED      { all $status[unmerged] | comp:decorate &style=$unmerged-style }
+  fn MOD-UNTRACKED { MODIFIED; UNTRACKED }
+  fn TRACKED       { set _ = ?(-run-git ls-files 2>&-) | comp:decorate &style=$tracked-style }
+  fn BRANCHES      {|&all=$false &branch=$true|
+    var -allarg = []
+    var -branch = ''
+    if $all { set -allarg = ['--all'] }
+    if $branch { set -branch = ' (branch)' }
+    set _ = ?(-run-git branch --list (all $-allarg) --format '%(refname:short)' 2>&- |
+    comp:decorate &display-suffix=$-branch &style=$branch-style)
+  }
+  fn REMOTE-BRANCHES {
+    set _ = ?(-run-git branch --list --remote --format '%(refname:short)' 2>&- |
+      grep -v HEAD |
+      each {|branch| re:replace 'origin/' '' $branch } |
+    comp:decorate &display-suffix=' (remote branch)' &style=$branch-style)
+  }
+  fn REMOTES       { set _ = ?(-run-git remote 2>&- | comp:decorate &display-suffix=' (remote)' &style=$remote-style ) }
+  fn STASHES       { set _ = ?(-run-git stash list 2>&- | each {|l| put [(re:split : $l)][0] } ) }
 #+end_src
 
 ** Initialization of completion definitions
@@ -165,56 +170,78 @@ fn STASHES       { _ = ?(-run-git stash list 2>&- | each [l]{ put [(re:split : $
 =$git:git-completions= contains the specialized completions for some git commands. Each sequence is a list of functions which return the possible completions at that point in the command. The =...= as a last element in some of them indicates that the last completion function is repeated for all further argument positions. The completion can also be a string, in which case it means an alias for some other command.
 
 #+begin_src elvish
-git-completions = [
-  &add=           [ [stem]{ MOD-UNTRACKED; UNMERGED; comp:dirs $stem } ... ]
-  &stage=         add
-  &checkout=      [ { MODIFIED; BRANCHES } ... ]
-  &switch=        [ { $BRANCHES~ &branch=$false; REMOTE-BRANCHES } ]
-  &mv=            [ [stem]{ TRACKED; comp:dirs $stem } ... ]
-  &rm=            [ [stem]{ TRACKED; comp:dirs $stem } ... ]
-  &diff=          [ { MODIFIED; BRANCHES  } ... ]
-  &push=          [ $REMOTES~ $BRANCHES~ ]
-  &pull=          [ $REMOTES~ { BRANCHES &all } ]
-  &merge=         [ $BRANCHES~ ... ]
-  &init=          [ [stem]{ put "."; comp:dirs $stem } ]
-  &branch=        [ $BRANCHES~ ... ]
-  &rebase=        [ { $BRANCHES~ &all } ... ]
-  &cherry=        [ { $BRANCHES~ &all } $BRANCHES~ $BRANCHES~ ]
-  &cherry-pick=   [ { $BRANCHES~ &all } ... ]
-  &stash=         [
-    &list= (comp:sequence [])
-    &clear= (comp:sequence [])
-    &show= (comp:sequence [ $STASHES~ ])
-    &drop= (comp:sequence &opts=[[&short=q &long=quiet]] [ $STASHES~ ])
-    &pop=   (comp:sequence &opts=[[&short=q &long=quiet] [&long=index]] [ $STASHES~ ])
-    &apply= pop
-    &branch= (comp:sequence [ [] $STASHES~ ])
-    &push= (comp:sequence [ $comp:files~ ... ] &opts=[
-        [&short=p &long=patch]
-        [&short=k &long=keep-index] [&long=no-keep-index]
-        [&short=q &long=quiet]
-        [&short=u &long=include-untracked]
-        [&short=a &long=all]
-        [&short=m &long=message &arg-required]
-    ])
-    &create= (comp:sequence [])
-    &store= (comp:sequence [ $BRANCHES~ ] &opts=[
-        [&short=m &long=message &arg-required]
-        [&short=q &long=quiet]
-    ])
+  var git-completions = [
+    &add=           [ {|stem| MOD-UNTRACKED; UNMERGED; comp:dirs $stem } ... ]
+    &stage=         add
+    &checkout=      [ { MODIFIED; BRANCHES } ... ]
+    &switch=        [ { $BRANCHES~ &branch=$false; REMOTE-BRANCHES } ]
+    &mv=            [ {|stem| TRACKED; comp:dirs $stem } ... ]
+    &rm=            [ {|stem| TRACKED; comp:dirs $stem } ... ]
+    &diff=          [ { MODIFIED; BRANCHES  } ... ]
+    &push=          [ $REMOTES~ $BRANCHES~ ]
+    &pull=          [ $REMOTES~ { BRANCHES &all } ]
+    &merge=         [ $BRANCHES~ ... ]
+    &init=          [ {|stem| put "."; comp:dirs $stem } ]
+    &branch=        [ $BRANCHES~ ... ]
+    &rebase=        [ { $BRANCHES~ &all } ... ]
+    &cherry=        [ { $BRANCHES~ &all } $BRANCHES~ $BRANCHES~ ]
+    &cherry-pick=   [ { $BRANCHES~ &all } ... ]
+    &stash=         [
+      &list= (comp:sequence [])
+      &clear= (comp:sequence [])
+      &show= (comp:sequence [ $STASHES~ ])
+      &drop= (comp:sequence &opts=[[&short=q &long=quiet]] [ $STASHES~ ])
+      &pop=   (comp:sequence &opts=[[&short=q &long=quiet] [&long=index]] [ $STASHES~ ])
+      &apply= pop
+      &branch= (comp:sequence [ [] $STASHES~ ])
+      &push= (comp:sequence [ $comp:files~ ... ] &opts=[
+          [&short=p &long=patch]
+          [&short=k &long=keep-index] [&long=no-keep-index]
+          [&short=q &long=quiet]
+          [&short=u &long=include-untracked]
+          [&short=a &long=all]
+          [&short=m &long=message &arg-required]
+      ])
+      &create= (comp:sequence [])
+      &store= (comp:sequence [ $BRANCHES~ ] &opts=[
+          [&short=m &long=message &arg-required]
+          [&short=q &long=quiet]
+      ])
+    ]
   ]
-]
 #+end_src
 
 In the =git:init= function we initialize the =$completions= map with the necessary data structure for =comp:subcommands= to provide the completions. We extract as much information as possible automatically from =git= itself.
 
 #+begin_src elvish :noweb yes
-fn init {
-  completions = [&]
-  <<init-git-commands>>
-  <<init-git-aliases>>
-  <<setup-completer>>
-}
+  fn init {
+    set completions = [&]
+    -run-git help -a --no-verbose | eawk {|line @f| if (re:match '^  [a-z]' $line) { put $@f } } | each {|c|
+      var seq = [ $comp:files~ ... ]
+      if (has-key $git-completions $c) {
+        set seq = $git-completions[$c]
+      }
+      if (eq (kind-of $seq) string) {
+        set completions[$c] = $seq
+      } elif (eq (kind-of $seq) map) {
+        set completions[$c] = (comp:subcommands $seq)
+      } else {
+        set completions[$c] = (comp:sequence $seq &opts={ -git-opts $c })
+      }
+    }
+    -run-git config --list | each {|l| re:find '^alias\.([^=]+)=(.*)$' $l } | each {|m|
+      var alias target = $m[groups][1 2][text]
+      if (has-key $completions $target) {
+        set completions[$alias] = $target
+      } else {
+        set completions[$alias] = (comp:sequence [])
+      }
+    }
+    set git-arg-completer = (comp:subcommands $completions ^
+      &pre-hook={|@_| set status = (git:status) } &opts={ -git-opts }
+    )
+    set edit:completion:arg-completer[git] = $git-arg-completer
+  }
 #+end_src
 
 Next , we fetch the list of valid git commands from the output of =git help -a=, and store the corresponding completion sequences in =$completions=. All of them are configured to produce  completions for their options, as extracted by the =-git-opts= function. Commands that have corresponding definitions in =$git-completions= get them, otherwise they get the generic filename completer.
@@ -260,7 +287,7 @@ edit:completion:arg-completer[git] = $git-arg-completer
 We run =init= by default on load, although it can be re-run if you change any configuration variables (most notably =git:git-command=).
 
 #+begin_src elvish
-init
+  init
 #+end_src
 
 * Test suite
@@ -270,16 +297,16 @@ init
 :END:
 
 #+begin_src elvish
-use github.com/zzamboni/elvish-completions/git
-use github.com/zzamboni/elvish-modules/test
+  use github.com/zzamboni/elvish-completions/git
+  use github.com/zzamboni/elvish-modules/test
 
-cmds = ($git:git-arg-completer git '')
+  var cmds = ($git:git-arg-completer git '')
 
-(test:set github.com/zzamboni/elvish-completions/git
-  (test:set "common top-level commands"
-    (test:check { has-value $cmds add })
-    (test:check { has-value $cmds checkout })
-    (test:check { has-value $cmds commit })
+  (test:set github.com/zzamboni/elvish-completions/git
+    (test:set "common top-level commands"
+      (test:check { has-value $cmds add })
+      (test:check { has-value $cmds checkout })
+      (test:check { has-value $cmds commit })
+    )
   )
-)
 #+end_src

--- a/git_test.elv
+++ b/git_test.elv
@@ -1,7 +1,7 @@
 use github.com/zzamboni/elvish-completions/git
 use github.com/zzamboni/elvish-modules/test
 
-cmds = ($git:git-arg-completer git '')
+var cmds = ($git:git-arg-completer git '')
 
 (test:set github.com/zzamboni/elvish-completions/git
   (test:set "common top-level commands"

--- a/ssh.elv
+++ b/ssh.elv
@@ -2,33 +2,33 @@ use ./comp
 use re
 use str
 
-config-files = [ ~/.ssh/config /etc/ssh/ssh_config /etc/ssh_config ]
+var config-files = [ ~/.ssh/config /etc/ssh/ssh_config /etc/ssh_config ]
 
 fn -ssh-hosts {
-  hosts = [&]
-  all $config-files | each [file]{
-    _ = ?(cat $file 2>&-) | eawk [_ @f]{
+  var hosts = [&]
+  all $config-files | each {|file|
+    set _ = ?(cat $file 2>&-) | eawk {|_ @f|
       if (re:match '^(?i)host$' $f[0]) {
-        all $f[1..] | each [p]{
+        all $f[1..] | each {|p|
           if (not (re:match '[*?!]' $p)) {
-            hosts[$p] = $true
+            set hosts[$p] = $true
   }}}}}
   keys $hosts
 }
 
--ssh-options = []
+var -ssh-options = []
 fn -gen-ssh-options {
   if (eq $-ssh-options []) {
-    -ssh-options = [(
-        _ = ?(cat (man -w ssh_config 2>&-)) |
-        eawk [l @f]{ if (re:match '^\.It Cm' $l) { put $f[2] } } |
+    set -ssh-options = [(
+        set _ = ?(cat (man -w ssh_config 2>&-)) |
+        eawk {|l @f| if (re:match '^\.It Cm' $l) { put $f[2] } } |
         comp:decorate &suffix='='
     )]
   }
   all $-ssh-options
 }
 
-ssh-opts = [
+var ssh-opts = [
   [ &short= o
     &arg-required= $true
     &arg-completer= $-gen-ssh-options~
@@ -40,15 +40,15 @@ ssh-opts = [
   ]
 ]
 
-fn -ssh-host-completions [arg &suffix='']{
-  user-given = (str:join '' [(re:find '^(.*@)' $arg)[groups][1][text]])
-  -ssh-hosts | each [host]{ put $user-given$host } | comp:decorate &suffix=$suffix
+fn -ssh-host-completions {|arg &suffix=''|
+  var user-given = (str:join '' [(re:find '^(.*@)' $arg)[groups][1][text]])
+  -ssh-hosts | each {|host| put $user-given$host } | comp:decorate &suffix=$suffix
 }
 
-edit:completion:arg-completer[ssh]  = (comp:sequence &opts=$ssh-opts [$-ssh-host-completions~])
-edit:completion:arg-completer[sftp] = (comp:sequence &opts=$ssh-opts [$-ssh-host-completions~])
-edit:completion:arg-completer[scp]  = (comp:sequence &opts=$ssh-opts [
-    [arg]{
+set edit:completion:arg-completer[ssh]  = (comp:sequence &opts=$ssh-opts [$-ssh-host-completions~])
+set edit:completion:arg-completer[sftp] = (comp:sequence &opts=$ssh-opts [$-ssh-host-completions~])
+set edit:completion:arg-completer[scp]  = (comp:sequence &opts=$ssh-opts [
+    {|arg|
       -ssh-host-completions &suffix=":" $arg
       edit:complete-filename $arg
     }

--- a/ssh.org
+++ b/ssh.org
@@ -64,15 +64,15 @@ Completions are also provided for config options. If you type =-o<space>=  and p
 We first load a number of libraries, including =comp=, the Elvish [[file:comp.org][completion framework]].
 
 #+begin_src elvish
-use ./comp
-use re
-use str
+  use ./comp
+  use re
+  use str
 #+end_src
 
 List of config files from which to extract hostnames.
 
 #+begin_src elvish :noweb yes
-<<config-files>>
+  var config-files = [ ~/.ssh/config /etc/ssh/ssh_config /etc/ssh_config ]
 #+end_src
 
 ** Initialization
@@ -80,33 +80,33 @@ List of config files from which to extract hostnames.
 The =-ssh-hosts= function extracts all hostnames from the files listed in =$config-files=. Nonexistent files in the list are ignored, and only hostnames which do not include glob characters (=*=, =?=, =!=) are returned.
 
 #+begin_src elvish
-fn -ssh-hosts {
-  hosts = [&]
-  all $config-files | each [file]{
-    _ = ?(cat $file 2>&-) | eawk [_ @f]{
-      if (re:match '^(?i)host$' $f[0]) {
-        all $f[1..] | each [p]{
-          if (not (re:match '[*?!]' $p)) {
-            hosts[$p] = $true
-  }}}}}
-  keys $hosts
-}
+  fn -ssh-hosts {
+    var hosts = [&]
+    all $config-files | each {|file|
+      set _ = ?(cat $file 2>&-) | eawk {|_ @f|
+        if (re:match '^(?i)host$' $f[0]) {
+          all $f[1..] | each {|p|
+            if (not (re:match '[*?!]' $p)) {
+              set hosts[$p] = $true
+    }}}}}
+    keys $hosts
+  }
 #+end_src
 
 We store in =-ssh-options= all the possible configuration options, by parsing them directly from the =ssh_config= man page (if available). These are initialized by the =-gen-ssh-options= on first use to reduce load time, and cached so that any delay is only incurred once.
 
 #+begin_src elvish
--ssh-options = []
-fn -gen-ssh-options {
-  if (eq $-ssh-options []) {
-    -ssh-options = [(
-        _ = ?(cat (man -w ssh_config 2>&-)) |
-        eawk [l @f]{ if (re:match '^\.It Cm' $l) { put $f[2] } } |
-        comp:decorate &suffix='='
-    )]
+  var -ssh-options = []
+  fn -gen-ssh-options {
+    if (eq $-ssh-options []) {
+      set -ssh-options = [(
+          set _ = ?(cat (man -w ssh_config 2>&-)) |
+          eawk {|l @f| if (re:match '^\.It Cm' $l) { put $f[2] } } |
+          comp:decorate &suffix='='
+      )]
+    }
+    all $-ssh-options
   }
-  all $-ssh-options
-}
 #+end_src
 
 The =$ssh-opts= array stores the definitions of command-line options. For now we only complete:
@@ -115,38 +115,38 @@ The =$ssh-opts= array stores the definitions of command-line options. For now we
 - =-i/--inventory= generated with =comp:files= defined in =comp.elv=
 
 #+begin_src elvish
-ssh-opts = [
-  [ &short= o
-    &arg-required= $true
-    &arg-completer= $-gen-ssh-options~
+  var ssh-opts = [
+    [ &short= o
+      &arg-required= $true
+      &arg-completer= $-gen-ssh-options~
+    ]
+    [ &short= i
+      &long= inventory
+      &arg-required= $true
+      &arg-completer= $comp:files~
+    ]
   ]
-  [ &short= i
-    &long= inventory
-    &arg-required= $true
-    &arg-completer= $comp:files~
-  ]
-]
 #+end_src
 
 =-ssh-host-completions= dynamically generates the completion definition for hostnames for ssh-related commands. The hostnames are extracted from the user's ssh config files by the =-ssh-hosts= function defined above. The completions for =ssh= and =scp=, for example, are the same except for the suffix that needs to be added to the hostnames in the completion, so we allow the suffix to be specified as an option. We also allow for a username to be specified at the beginning of the hostname (=user@=), and still generate the completions correctly, so you can type =ssh user@abc<Tab>= and the corresponding hostnames will be completed.
 
 #+begin_src elvish
-fn -ssh-host-completions [arg &suffix='']{
-  user-given = (str:join '' [(re:find '^(.*@)' $arg)[groups][1][text]])
-  -ssh-hosts | each [host]{ put $user-given$host } | comp:decorate &suffix=$suffix
-}
+  fn -ssh-host-completions {|arg &suffix=''|
+    var user-given = (str:join '' [(re:find '^(.*@)' $arg)[groups][1][text]])
+    -ssh-hosts | each {|host| put $user-given$host } | comp:decorate &suffix=$suffix
+  }
 #+end_src
 
 We use =-ssh-host-completions= to produce the actual completion definitions for =ssh=, =sftp= and =scp=. For =scp= we also complete local filenames.
 
 #+begin_src elvish
-edit:completion:arg-completer[ssh]  = (comp:sequence &opts=$ssh-opts [$-ssh-host-completions~])
-edit:completion:arg-completer[sftp] = (comp:sequence &opts=$ssh-opts [$-ssh-host-completions~])
-edit:completion:arg-completer[scp]  = (comp:sequence &opts=$ssh-opts [
-    [arg]{
-      -ssh-host-completions &suffix=":" $arg
-      edit:complete-filename $arg
-    }
-    ...
-])
+  set edit:completion:arg-completer[ssh]  = (comp:sequence &opts=$ssh-opts [$-ssh-host-completions~])
+  set edit:completion:arg-completer[sftp] = (comp:sequence &opts=$ssh-opts [$-ssh-host-completions~])
+  set edit:completion:arg-completer[scp]  = (comp:sequence &opts=$ssh-opts [
+      {|arg|
+        -ssh-host-completions &suffix=":" $arg
+        edit:complete-filename $arg
+      }
+      ...
+  ])
 #+end_src

--- a/vcsh.elv
+++ b/vcsh.elv
@@ -5,16 +5,16 @@ use ./git
 use re
 
 # Return all elements in $l1 except those who are already in $l2
-fn -all-except [l1 l2]{
-  each [x]{ if (not (has-value $l2 $x)) { put $x } } $l1
+fn -all-except {|l1 l2|
+  each {|x| if (not (has-value $l2 $x)) { put $x } } $l1
 }
 
-fn vcsh-completer [cmd @rest]{
-  n = (count $rest)
-  repos = [(vcsh list)]
+fn vcsh-completer {|cmd @rest|
+  var n = (count $rest)
+  var repos = [(vcsh list)]
   if (eq $n 1) {
     # Extract valid commands and options from the vcsh help message itself
-    cmds = [(vcsh 2>&1 | grep '^   [a-z-]' | grep -v ':$' | awk '{print $1}')]
+    var cmds = [(vcsh 2>&1 | grep '^   [a-z-]' | grep -v ':$' | awk '{print $1}')]
     put $@repos $@cmds
   } elif (and (> $n 1) (has-value $repos $rest[0])) {
     put (git:git-completer $cmd" "$rest[0] (all $rest[1..]))
@@ -37,4 +37,4 @@ fn vcsh-completer [cmd @rest]{
   }
 }
 
-edit:completion:arg-completer[vcsh] = $vcsh-completer~
+set edit:completion:arg-completer[vcsh] = $vcsh-completer~

--- a/vcsh.org
+++ b/vcsh.org
@@ -12,44 +12,44 @@ Completions for [[https://github.com/RichiH/vcsh][vcsh]].
 :END:
 
 #+begin_src elvish
-# Completer for vcsh - https://github.com/RichiH/vcsh
-# Diego Zamboni <diego@zzamboni.org>
+  # Completer for vcsh - https://github.com/RichiH/vcsh
+  # Diego Zamboni <diego@zzamboni.org>
 
-use ./git
-use re
+  use ./git
+  use re
 
-# Return all elements in $l1 except those who are already in $l2
-fn -all-except [l1 l2]{
-  each [x]{ if (not (has-value $l2 $x)) { put $x } } $l1
-}
-
-fn vcsh-completer [cmd @rest]{
-  n = (count $rest)
-  repos = [(vcsh list)]
-  if (eq $n 1) {
-    # Extract valid commands and options from the vcsh help message itself
-    cmds = [(vcsh 2>&1 | grep '^   [a-z-]' | grep -v ':$' | awk '{print $1}')]
-    put $@repos $@cmds
-  } elif (and (> $n 1) (has-value $repos $rest[0])) {
-    put (git:git-completer $cmd" "$rest[0] (all $rest[1..]))
-  } elif (eq $n 2) {
-    # Subcommand- or option-specific completions
-    if (eq $rest[0] "-c") {
-      put (edit:complete-filename $rest[1])
-    } elif (re:match "delete|enter|rename|run|upgrade|write-ignore|list-tracked" $rest[0]) {
-      put $@repos
-    } elif (eq $rest[0] "list-untracked") {
-      put $@repos "-a" "-r"
-    } elif (eq $rest[0] "status") {
-      put $@repos "--terse"
-    }
-  } elif (> $n 2) {
-    # For more than two arguments, we recurse, removing any options that have been typed already
-    # Not perfect but it allows completion to work properly after "vcsh status --terse", for example,
-    # without too much repetition
-    put (-all-except [(vcsh-completer $cmd (all $rest[0:(- $n 1)]))] $rest[0:(- $n 1)])
+  # Return all elements in $l1 except those who are already in $l2
+  fn -all-except {|l1 l2|
+    each {|x| if (not (has-value $l2 $x)) { put $x } } $l1
   }
-}
 
-edit:completion:arg-completer[vcsh] = $vcsh-completer~
+  fn vcsh-completer {|cmd @rest|
+    var n = (count $rest)
+    var repos = [(vcsh list)]
+    if (eq $n 1) {
+      # Extract valid commands and options from the vcsh help message itself
+      var cmds = [(vcsh 2>&1 | grep '^   [a-z-]' | grep -v ':$' | awk '{print $1}')]
+      put $@repos $@cmds
+    } elif (and (> $n 1) (has-value $repos $rest[0])) {
+      put (git:git-completer $cmd" "$rest[0] (all $rest[1..]))
+    } elif (eq $n 2) {
+      # Subcommand- or option-specific completions
+      if (eq $rest[0] "-c") {
+        put (edit:complete-filename $rest[1])
+      } elif (re:match "delete|enter|rename|run|upgrade|write-ignore|list-tracked" $rest[0]) {
+        put $@repos
+      } elif (eq $rest[0] "list-untracked") {
+        put $@repos "-a" "-r"
+      } elif (eq $rest[0] "status") {
+        put $@repos "--terse"
+      }
+    } elif (> $n 2) {
+      # For more than two arguments, we recurse, removing any options that have been typed already
+      # Not perfect but it allows completion to work properly after "vcsh status --terse", for example,
+      # without too much repetition
+      put (-all-except [(vcsh-completer $cmd (all $rest[0:(- $n 1)]))] $rest[0:(- $n 1)])
+    }
+  }
+
+  set edit:completion:arg-completer[vcsh] = $vcsh-completer~
 #+end_src


### PR DESCRIPTION
Upgrade was done using https://go.elv.sh/u0.17, with some
additional tooling to automatically de-tangle the changes
back into the .org files.