### PR TITLE
fix a style bug in git:TRACKED

### DIFF
--- a/git.elv
+++ b/git.elv
@@ -14,7 +14,7 @@ var git-command = git
 
 var modified-style  = yellow
 var untracked-style = red
-var tracked-style   = ''
+var tracked-style   = $nil
 var branch-style    = blue
 var remote-style    = cyan
 var unmerged-style  = magenta


### PR DESCRIPTION
Empty string is not a valid style transformer, let's use `$nil` instead for non-style.

```
~> use github.com/zzamboni/elvish-completions/git
~> git:TRACKED
Exception: '' is not a valid style transformer
Traceback:
  /home/tw/.local/share/elvish/lib/github.com/zzamboni/elvish-completions/comp.elv, line 24:
          set k-display = (styled $k $style)
  /home/tw/.local/share/elvish/lib/github.com/zzamboni/elvish-completions/comp.elv, line 21-27:
      each {|k|
        var k-display = $k
        if $style {
          set k-display = (styled $k $style)
        }
        edit:complex-candidate &code-suffix=$code-suffix &display=$k-display$display-suffix $k
      } $input
  /home/tw/.local/share/elvish/lib/github.com/zzamboni/elvish-completions/git.elv, line 46:
    fn TRACKED       { set _ = ?(-run-git ls-files 2>&-) | comp:decorate &style=$tracked-style }
  [tty 439], line 1:
    git:TRACKED
error: no candidates
```

Signed-off-by: Tw <tw19881113@gmail.com>