### PR TITLE
fix completion for git alias

### DIFF
--- a/git.elv
+++ b/git.elv
@@ -116,7 +116,7 @@ fn init {
       set completions[$c] = (comp:sequence $seq &opts={ -git-opts $c })
     }
   }
-  -run-git config --list | each {|l| re:find '^alias\.([^=]+)=(.*)$' $l } | each {|m|
+  -run-git config --list | each {|l| re:find '^alias\.([^=]+)=(\S+)' $l } | each {|m|
     var alias target = $m[groups][1 2][text]
     if (has-key $completions $target) {
       set completions[$alias] = $target


### PR DESCRIPTION
git alias may contain some options, like `alias ci=commit -s`. So adjust the regex to only capture the first word after equal mark as the target.