### PR TITLE
Fix eawk deprecation warnings

### DIFF
--- a/ssh.elv
+++ b/ssh.elv
@@ -7,7 +7,7 @@ var config-files = [ ~/.ssh/config /etc/ssh/ssh_config /etc/ssh_config ]
 fn -ssh-hosts {
   var hosts = [&]
   all $config-files | each {|file|
-    set _ = ?(cat $file 2>&-) | eawk {|_ @f|
+    set _ = ?(cat $file 2>&-) | re:eawk {|_ @f|
       if (re:match '^(?i)host$' $f[0]) {
         all $f[1..] | each {|p|
           if (not (re:match '[*?!]' $p)) {
@@ -21,7 +21,7 @@ fn -gen-ssh-options {
   if (eq $-ssh-options []) {
     set -ssh-options = [(
         set _ = ?(cat (man -w ssh_config 2>&-)) |
-        eawk {|l @f| if (re:match '^\.It Cm' $l) { put $f[2] } } |
+        re:eawk {|l @f| if (re:match '^\.It Cm' $l) { put $f[2] } } |
         comp:decorate &suffix='='
     )]
   }

--- a/ssh.org
+++ b/ssh.org
@@ -83,7 +83,7 @@ The =-ssh-hosts= function extracts all hostnames from the files listed in =$conf
   fn -ssh-hosts {
     var hosts = [&]
     all $config-files | each {|file|
-      set _ = ?(cat $file 2>&-) | eawk {|_ @f|
+      set _ = ?(cat $file 2>&-) | re:eawk {|_ @f|
         if (re:match '^(?i)host$' $f[0]) {
           all $f[1..] | each {|p|
             if (not (re:match '[*?!]' $p)) {
@@ -101,7 +101,7 @@ We store in =-ssh-options= all the possible configuration options, by parsing th
     if (eq $-ssh-options []) {
       set -ssh-options = [(
           set _ = ?(cat (man -w ssh_config 2>&-)) |
-          eawk {|l @f| if (re:match '^\.It Cm' $l) { put $f[2] } } |
+          re:eawk {|l @f| if (re:match '^\.It Cm' $l) { put $f[2] } } |
           comp:decorate &suffix='='
       )]
     }


### PR DESCRIPTION
Fix deprecation warnings in elvish
```
Deprecation: the "eawk" command is deprecated; use "re:awk" instead
```