### PR TITLE
Use re:awk instead of eawk for 0.20 compatibility

### DIFF
--- a/comp.org
+++ b/comp.org
@@ -181,7 +181,7 @@ vagrant-completions = [
       &add= (comp:sequence [] \
         &opts= { vagrant box add -h | comp:extract-opts }
       )
-      &remove= (comp:sequence [ { vagrant box list | eawk [_ @f]{ put $f[0] } } ... ] \
+      &remove= (comp:sequence [ { vagrant box list | re:awk [_ @f]{ put $f[0] } } ... ] \
         &opts= { vagrant box remove -h | comp:extract-opts }
       )
 ])]

--- a/evemu.elv
+++ b/evemu.elv
@@ -1,5 +1,6 @@
 use ./comp
 use str
+use re
 
 var -complete-dev = {
   var evdev-dir = '/dev/input/'
@@ -16,7 +17,7 @@ var ev-code-header = /usr/include/linux/input-event-codes.h
 
 fn -defs-with-prefix {|prefix|
   grep "#define "$prefix"_" $ev-code-header |
-      eawk {|line @fields| put $fields[1] }
+      re:awk {|line @fields| put $fields[1] }
 }
 
 fn -ev-codes-for-type {|type|

--- a/evemu.org
+++ b/evemu.org
@@ -36,7 +36,7 @@ Some commands take axis or key constants defined in the Kernel's =input-event-co
 
   fn -defs-with-prefix {|prefix|
     grep "#define "$prefix"_" $ev-code-header |
-        eawk {|line @fields| put $fields[1] }
+        re:awk {|line @fields| put $fields[1] }
   }
 #+end_src
 

--- a/git.elv
+++ b/git.elv
@@ -103,7 +103,7 @@ var git-completions = [
 
 fn init {
   set completions = [&]
-  -run-git help -a --no-verbose | eawk {|line @f| if (re:match '^  [a-z]' $line) { put $@f } } | each {|c|
+  -run-git help -a --no-verbose | re:awk {|line @f| if (re:match '^  [a-z]' $line) { put $@f } } | each {|c|
     var seq = [ $comp:files~ ... ]
     if (has-key $git-completions $c) {
       set seq = $git-completions[$c]

--- a/git.org
+++ b/git.org
@@ -216,7 +216,7 @@ In the =git:init= function we initialize the =$completions= map with the necessa
 #+begin_src elvish :noweb yes
   fn init {
     set completions = [&]
-    -run-git help -a --no-verbose | eawk {|line @f| if (re:match '^  [a-z]' $line) { put $@f } } | each {|c|
+    -run-git help -a --no-verbose | re:awk {|line @f| if (re:match '^  [a-z]' $line) { put $@f } } | each {|c|
       var seq = [ $comp:files~ ... ]
       if (has-key $git-completions $c) {
         set seq = $git-completions[$c]
@@ -247,7 +247,7 @@ In the =git:init= function we initialize the =$completions= map with the necessa
 Next , we fetch the list of valid git commands from the output of =git help -a=, and store the corresponding completion sequences in =$completions=. All of them are configured to produce  completions for their options, as extracted by the =-git-opts= function. Commands that have corresponding definitions in =$git-completions= get them, otherwise they get the generic filename completer.
 
 #+begin_src elvish :noweb-ref init-git-commands :tangle no
--run-git help -a --no-verbose | eawk [line @f]{ if (re:match '^  [a-z]' $line) { put $@f } } | each [c]{
+-run-git help -a --no-verbose | re:awk [line @f]{ if (re:match '^  [a-z]' $line) { put $@f } } | each [c]{
   seq = [ $comp:files~ ... ]
   if (has-key $git-completions $c) {
     seq = $git-completions[$c]

--- a/ssh.elv
+++ b/ssh.elv
@@ -7,7 +7,7 @@ var config-files = [ ~/.ssh/config /etc/ssh/ssh_config /etc/ssh_config ]
 fn -ssh-hosts {
   var hosts = [&]
   all $config-files | each {|file|
-    set _ = ?(cat $file 2>&-) | eawk {|_ @f|
+    set _ = ?(cat $file 2>&-) | re:awk {|_ @f|
       if (re:match '^(?i)host$' $f[0]) {
         all $f[1..] | each {|p|
           if (not (re:match '[*?!]' $p)) {
@@ -21,7 +21,7 @@ fn -gen-ssh-options {
   if (eq $-ssh-options []) {
     set -ssh-options = [(
         set _ = ?(cat (man -w ssh_config 2>&-)) |
-        eawk {|l @f| if (re:match '^\.It Cm' $l) { put $f[2] } } |
+        re:awk {|l @f| if (re:match '^\.It Cm' $l) { put $f[2] } } |
         comp:decorate &suffix='='
     )]
   }

--- a/ssh.org
+++ b/ssh.org
@@ -83,7 +83,7 @@ The =-ssh-hosts= function extracts all hostnames from the files listed in =$conf
   fn -ssh-hosts {
     var hosts = [&]
     all $config-files | each {|file|
-      set _ = ?(cat $file 2>&-) | eawk {|_ @f|
+      set _ = ?(cat $file 2>&-) | re:awk {|_ @f|
         if (re:match '^(?i)host$' $f[0]) {
           all $f[1..] | each {|p|
             if (not (re:match '[*?!]' $p)) {
@@ -101,7 +101,7 @@ We store in =-ssh-options= all the possible configuration options, by parsing th
     if (eq $-ssh-options []) {
       set -ssh-options = [(
           set _ = ?(cat (man -w ssh_config 2>&-)) |
-          eawk {|l @f| if (re:match '^\.It Cm' $l) { put $f[2] } } |
+          re:awk {|l @f| if (re:match '^\.It Cm' $l) { put $f[2] } } |
           comp:decorate &suffix='='
       )]
     }


### PR DESCRIPTION
0.20.0 deprecated `eawk` in favour of `re:awk`. This commit reflects this change.