### PR TITLE
Replace uses of `eawk` with `re:awk`

### DIFF
--- a/comp.org
+++ b/comp.org
@@ -173,6 +173,8 @@ edit:completion:arg-completer[brew] = (comp:subcommands &opts= [ version ] $brew
 *Tip:* note that the values of =&opts= are functions (e.g. ={ vagrant-up -h | comp:extract-opts }=) instead of arrays (e.g. =( vagrant up -h | comp:extract-opts )=). As mentioned in Example #5, both would be valid, but in the latter case they are all initialized at load time (when the data structure is defined), which might introduce a delay (particularly with more command definitions). By using functions the options are only extracted at runtime when the completion is requested. For further optimization, =vagrant-opts= could be made to memoize the values so that the delay only occurs the first time.
 
 #+begin_src elvish
+use re
+
 vagrant-completions = [
   &up= (comp:sequence [] \
     &opts= { vagrant up -h | comp:extract-opts }
@@ -181,7 +183,7 @@ vagrant-completions = [
       &add= (comp:sequence [] \
         &opts= { vagrant box add -h | comp:extract-opts }
       )
-      &remove= (comp:sequence [ { vagrant box list | eawk [_ @f]{ put $f[0] } } ... ] \
+      &remove= (comp:sequence [ { vagrant box list | re:awk [_ @f]{ put $f[0] } } ... ] \
         &opts= { vagrant box remove -h | comp:extract-opts }
       )
 ])]

--- a/evemu.elv
+++ b/evemu.elv
@@ -1,4 +1,5 @@
 use ./comp
+use re
 use str
 
 var -complete-dev = {
@@ -16,7 +17,7 @@ var ev-code-header = /usr/include/linux/input-event-codes.h
 
 fn -defs-with-prefix {|prefix|
   grep "#define "$prefix"_" $ev-code-header |
-      eawk {|line @fields| put $fields[1] }
+      re:awk {|line @fields| put $fields[1] }
 }
 
 fn -ev-codes-for-type {|type|

--- a/evemu.org
+++ b/evemu.org
@@ -15,6 +15,7 @@ All of these commands operate on evdev nodes, contained in =/dev/input/=. Each r
 
 #+begin_src elvish
   use ./comp
+  use re
   use str
 
   var -complete-dev = {
@@ -36,7 +37,7 @@ Some commands take axis or key constants defined in the Kernel's =input-event-co
 
   fn -defs-with-prefix {|prefix|
     grep "#define "$prefix"_" $ev-code-header |
-        eawk {|line @fields| put $fields[1] }
+        re:awk {|line @fields| put $fields[1] }
   }
 #+end_src
 

--- a/git.elv
+++ b/git.elv
@@ -103,7 +103,7 @@ var git-completions = [
 
 fn init {
   set completions = [&]
-  -run-git help -a --no-verbose | eawk {|line @f| if (re:match '^  [a-z]' $line) { put $@f } } | each {|c|
+  -run-git help -a --no-verbose | re:awk {|line @f| if (re:match '^  [a-z]' $line) { put $@f } } | each {|c|
     var seq = [ $comp:files~ ... ]
     if (has-key $git-completions $c) {
       set seq = $git-completions[$c]

--- a/git.org
+++ b/git.org
@@ -216,7 +216,7 @@ In the =git:init= function we initialize the =$completions= map with the necessa
 #+begin_src elvish :noweb yes
   fn init {
     set completions = [&]
-    -run-git help -a --no-verbose | eawk {|line @f| if (re:match '^  [a-z]' $line) { put $@f } } | each {|c|
+    -run-git help -a --no-verbose | re:awk {|line @f| if (re:match '^  [a-z]' $line) { put $@f } } | each {|c|
       var seq = [ $comp:files~ ... ]
       if (has-key $git-completions $c) {
         set seq = $git-completions[$c]
@@ -247,7 +247,7 @@ In the =git:init= function we initialize the =$completions= map with the necessa
 Next , we fetch the list of valid git commands from the output of =git help -a=, and store the corresponding completion sequences in =$completions=. All of them are configured to produce  completions for their options, as extracted by the =-git-opts= function. Commands that have corresponding definitions in =$git-completions= get them, otherwise they get the generic filename completer.
 
 #+begin_src elvish :noweb-ref init-git-commands :tangle no
--run-git help -a --no-verbose | eawk [line @f]{ if (re:match '^  [a-z]' $line) { put $@f } } | each [c]{
+-run-git help -a --no-verbose | re:awk [line @f]{ if (re:match '^  [a-z]' $line) { put $@f } } | each [c]{
   seq = [ $comp:files~ ... ]
   if (has-key $git-completions $c) {
     seq = $git-completions[$c]

--- a/ssh.elv
+++ b/ssh.elv
@@ -7,7 +7,7 @@ var config-files = [ ~/.ssh/config /etc/ssh/ssh_config /etc/ssh_config ]
 fn -ssh-hosts {
   var hosts = [&]
   all $config-files | each {|file|
-    set _ = ?(cat $file 2>&-) | eawk {|_ @f|
+    set _ = ?(cat $file 2>&-) | re:awk {|_ @f|
       if (re:match '^(?i)host$' $f[0]) {
         all $f[1..] | each {|p|
           if (not (re:match '[*?!]' $p)) {
@@ -21,7 +21,7 @@ fn -gen-ssh-options {
   if (eq $-ssh-options []) {
     set -ssh-options = [(
         set _ = ?(cat (man -w ssh_config 2>&-)) |
-        eawk {|l @f| if (re:match '^\.It Cm' $l) { put $f[2] } } |
+        re:awk {|l @f| if (re:match '^\.It Cm' $l) { put $f[2] } } |
         comp:decorate &suffix='='
     )]
   }

--- a/ssh.org
+++ b/ssh.org
@@ -83,7 +83,7 @@ The =-ssh-hosts= function extracts all hostnames from the files listed in =$conf
   fn -ssh-hosts {
     var hosts = [&]
     all $config-files | each {|file|
-      set _ = ?(cat $file 2>&-) | eawk {|_ @f|
+      set _ = ?(cat $file 2>&-) | re:awk {|_ @f|
         if (re:match '^(?i)host$' $f[0]) {
           all $f[1..] | each {|p|
             if (not (re:match '[*?!]' $p)) {
@@ -101,7 +101,7 @@ We store in =-ssh-options= all the possible configuration options, by parsing th
     if (eq $-ssh-options []) {
       set -ssh-options = [(
           set _ = ?(cat (man -w ssh_config 2>&-)) |
-          eawk {|l @f| if (re:match '^\.It Cm' $l) { put $f[2] } } |
+          re:awk {|l @f| if (re:match '^\.It Cm' $l) { put $f[2] } } |
           comp:decorate &suffix='='
       )]
     }


### PR DESCRIPTION
`eawk` was [deprecated in version 0.20.0](https://elv.sh/blog/0.20.0-release-notes.html#deprecated-features).